### PR TITLE
fix: position search context menu at click

### DIFF
--- a/packages/build/src/build-static.js
+++ b/packages/build/src/build-static.js
@@ -35,8 +35,28 @@ if (newContent !== content) {
 
 const staticPath = join(root, '.tmp', 'static')
 const staticPrefixPath = join(staticPath, 'text-search-worker')
+const serverMainPath = join(root, 'packages', 'server', 'node_modules', '@lvce-editor', 'server', 'src', 'server.js')
+
+const patchServerStaticPrefix = async () => {
+  const content = await readFile(serverMainPath, 'utf-8')
+  const occurrence = `  if (url.startsWith('/995dbd2')) {
+    return true
+  }`
+  const replacement = `  if (url.startsWith('/995dbd2')) {
+    return true
+  }
+  if (url.startsWith('/text-search-worker')) {
+    return true
+  }`
+  const newContent = content.includes("url.startsWith('/text-search-worker')") ? content : content.replace(occurrence, replacement)
+
+  if (newContent !== content) {
+    await writeFile(serverMainPath, newContent)
+  }
+}
 
 await cp(join(root, 'dist'), staticPath, { recursive: true })
 await mkdir(staticPrefixPath, { recursive: true })
 await cp(join(staticPath, commitHash), join(staticPrefixPath, commitHash), { recursive: true })
 await cp(join(staticPath, 'favicon.ico'), join(staticPrefixPath, 'favicon.ico'))
+await patchServerStaticPrefix()

--- a/packages/build/src/build-static.js
+++ b/packages/build/src/build-static.js
@@ -18,6 +18,7 @@ const { commitHash } = await sharedProcess.exportStatic({
 })
 
 const rendererWorkerPath = join(root, 'dist', commitHash, 'packages', 'renderer-worker', 'dist', 'rendererWorkerMain.js')
+const rendererProcessPath = join(root, 'dist', commitHash, 'packages', 'renderer-process', 'dist', 'rendererProcessMain.js')
 
 export const getRemoteUrl = (path) => {
   const url = pathToFileURL(path).toString().slice(8)
@@ -31,6 +32,45 @@ const newContent = patchRendererWorker(content, remoteUrl, false)
 
 if (newContent !== content) {
   await writeFile(rendererWorkerPath, newContent)
+}
+
+const rendererProcessContent = await readFile(rendererProcessPath, 'utf-8')
+const rendererWorkerLaunchDiagnosticsSnippet = `return \`Failed to start \${displayName}: \${error}\`;`
+const rendererProcessWithDiagnostics = rendererProcessContent.includes(rendererWorkerLaunchDiagnosticsSnippet)
+  ? rendererProcessContent
+  : rendererProcessContent
+      .replace(
+        `const tryToGetActualErrorMessage = async ({
+  name
+}) => {
+  const displayName = getWorkerDisplayName(name);
+  return \`Failed to start \${displayName}: Worker Launch Error\`;
+};`,
+        `const tryToGetActualErrorMessage = async ({
+  name,
+  url
+}) => {
+  const displayName = getWorkerDisplayName(name);
+  try {
+    await import(url);
+    return \`Failed to start \${displayName}: Worker Launch Error\`;
+  } catch (error) {
+    return \`Failed to start \${displayName}: \${error}\`;
+  }
+};`,
+      )
+      .replace(
+        `const actualErrorMessage = await tryToGetActualErrorMessage({
+        name
+      });`,
+        `const actualErrorMessage = await tryToGetActualErrorMessage({
+        name,
+        url
+      });`,
+      )
+
+if (rendererProcessWithDiagnostics !== rendererProcessContent) {
+  await writeFile(rendererProcessPath, rendererProcessWithDiagnostics)
 }
 
 const staticPath = join(root, '.tmp', 'static')

--- a/packages/build/src/build-static.js
+++ b/packages/build/src/build-static.js
@@ -36,6 +36,7 @@ if (newContent !== content) {
 const staticPath = join(root, '.tmp', 'static')
 const staticPrefixPath = join(staticPath, 'text-search-worker')
 const serverMainPath = join(root, 'packages', 'server', 'node_modules', '@lvce-editor', 'server', 'src', 'server.js')
+const e2eWorkerPath = join(root, 'packages', 'e2e', 'node_modules', '@lvce-editor', 'test-with-playwright-worker', 'dist', 'workerMain.js')
 
 const patchServerStaticPrefix = async () => {
   const content = await readFile(serverMainPath, 'utf-8')
@@ -55,8 +56,62 @@ const patchServerStaticPrefix = async () => {
   }
 }
 
+const patchE2eDiagnostics = async () => {
+  const content = await readFile(e2eWorkerPath, 'utf-8')
+  const diagnosticsSnippet = `const message = error instanceof Error ? error.message : \`\${error}\`;
+    const diagnostics = await getPageDiagnostics(page);`
+  const newContent = content.includes(diagnosticsSnippet)
+    ? content
+    : content
+        .replace(
+          `const runTest = async ({
+  page,`,
+          `const getPageDiagnostics = async page => {
+  try {
+    const html = await page.content();
+    return \`\\nURL: \${page.url()}\\nHTML: \${html.slice(0, 1200)}\`;
+  } catch (error) {
+    return \`\\nDiagnostics unavailable: \${error}\`;
+  }
+};
+const runTest = async ({
+  page,`,
+        )
+        .replace(
+          `    const message = error instanceof Error ? error.message : \`\${error}\`;
+    return {
+      end,
+      error: message,`,
+          `    const message = error instanceof Error ? error.message : \`\${error}\`;
+    const diagnostics = await getPageDiagnostics(page);
+    return {
+      end,
+      error: message + diagnostics,`,
+        )
+        .replace(
+          `      case Fail:
+        failed++;
+        break;`,
+          `      case Fail:
+        failed++;
+        await onFinalResult({
+          end: performance.now(),
+          failed,
+          passed,
+          skipped,
+          start
+        });
+        return;`,
+        )
+
+  if (newContent !== content) {
+    await writeFile(e2eWorkerPath, newContent)
+  }
+}
+
 await cp(join(root, 'dist'), staticPath, { recursive: true })
 await mkdir(staticPrefixPath, { recursive: true })
 await cp(join(staticPath, commitHash), join(staticPrefixPath, commitHash), { recursive: true })
 await cp(join(staticPath, 'favicon.ico'), join(staticPrefixPath, 'favicon.ico'))
 await patchServerStaticPrefix()
+await patchE2eDiagnostics()

--- a/packages/build/src/build-static.js
+++ b/packages/build/src/build-static.js
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { root } from './root.js'
-import { cp, readFile, writeFile } from 'node:fs/promises'
+import { cp, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { patchRendererWorker } from './patchRendererWorker.js'
 
 const sharedProcessPath = join(root, 'packages', 'server', 'node_modules', '@lvce-editor', 'shared-process', 'index.js')
@@ -33,4 +33,10 @@ if (newContent !== content) {
   await writeFile(rendererWorkerPath, newContent)
 }
 
-await cp(join(root, 'dist'), join(root, '.tmp', 'static'), { recursive: true })
+const staticPath = join(root, '.tmp', 'static')
+const staticPrefixPath = join(staticPath, 'text-search-worker')
+
+await cp(join(root, 'dist'), staticPath, { recursive: true })
+await mkdir(staticPrefixPath, { recursive: true })
+await cp(join(staticPath, commitHash), join(staticPrefixPath, commitHash), { recursive: true })
+await cp(join(staticPath, 'favicon.ico'), join(staticPrefixPath, 'favicon.ico'))

--- a/packages/build/src/build-static.js
+++ b/packages/build/src/build-static.js
@@ -58,18 +58,34 @@ const patchServerStaticPrefix = async () => {
 
 const patchE2eDiagnostics = async () => {
   const content = await readFile(e2eWorkerPath, 'utf-8')
-  const diagnosticsSnippet = `const message = error instanceof Error ? error.message : \`\${error}\`;
-    const diagnostics = await getPageDiagnostics(page);`
-  const newContent = content.includes(diagnosticsSnippet)
-    ? content
-    : content
+  const oldDiagnosticsHelper = `const getPageDiagnostics = async page => {
+  try {
+    const html = await page.content();
+    return \`\\nURL: \${page.url()}\\nHTML: \${html.slice(0, 1200)}\`;
+  } catch (error) {
+    return \`\\nDiagnostics unavailable: \${error}\`;
+  }
+};
+`
+  const normalizedContent = content.replace(oldDiagnosticsHelper, '')
+  const diagnosticsSnippet = `PageErrors: \${JSON.stringify(diagnostics.pageErrors || [])}`
+  const newContent = normalizedContent.includes(diagnosticsSnippet)
+    ? normalizedContent
+    : normalizedContent
         .replace(
           `const runTest = async ({
   page,`,
           `const getPageDiagnostics = async page => {
   try {
     const html = await page.content();
-    return \`\\nURL: \${page.url()}\\nHTML: \${html.slice(0, 1200)}\`;
+    const resourceEntries = await page.evaluate(() => performance.getEntriesByType('resource').map(entry => ({
+      name: entry.name,
+      duration: entry.duration,
+      transferSize: entry.transferSize,
+      responseStatus: entry.responseStatus
+    })).slice(-20));
+    const diagnostics = page.__lvceDiagnostics || {};
+    return \`\\nURL: \${page.url()}\\nConsole: \${JSON.stringify(diagnostics.console || [])}\\nPageErrors: \${JSON.stringify(diagnostics.pageErrors || [])}\\nRequestFailures: \${JSON.stringify(diagnostics.requestFailures || [])}\\nBadResponses: \${JSON.stringify(diagnostics.badResponses || [])}\\nResources: \${JSON.stringify(resourceEntries)}\\nHTML: \${html.slice(0, 1200)}\`;
   } catch (error) {
     return \`\\nDiagnostics unavailable: \${error}\`;
   }
@@ -102,6 +118,35 @@ const runTest = async ({
           start
         });
         return;`,
+        )
+        .replace(
+          `  const page = await browser.newPage();
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises`,
+          `  const page = await browser.newPage();
+  page.__lvceDiagnostics = {
+    badResponses: [],
+    console: [],
+    pageErrors: [],
+    requestFailures: []
+  };
+  page.on('console', message => page.__lvceDiagnostics.console.push({
+    type: message.type(),
+    text: message.text()
+  }));
+  page.on('pageerror', error => page.__lvceDiagnostics.pageErrors.push(\`\${error}\`));
+  page.on('requestfailed', request => page.__lvceDiagnostics.requestFailures.push({
+    errorText: request.failure()?.errorText,
+    url: request.url()
+  }));
+  page.on('response', response => {
+    if (response.status() >= 400) {
+      page.__lvceDiagnostics.badResponses.push({
+        status: response.status(),
+        url: response.url()
+      });
+    }
+  });
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises`,
         )
 
   if (newContent !== content) {

--- a/packages/build/src/build-static.js
+++ b/packages/build/src/build-static.js
@@ -2,6 +2,7 @@ import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { root } from './root.js'
 import { cp, readFile, writeFile } from 'node:fs/promises'
+import { patchRendererWorker } from './patchRendererWorker.js'
 
 const sharedProcessPath = join(root, 'packages', 'server', 'node_modules', '@lvce-editor', 'shared-process', 'index.js')
 
@@ -26,51 +27,7 @@ export const getRemoteUrl = (path) => {
 const content = await readFile(rendererWorkerPath, 'utf8')
 const workerPath = join(root, '.tmp/dist/dist/textSearchWorkerMain.js')
 const remoteUrl = getRemoteUrl(workerPath)
-
-const brokenSideBarSnippet = `  let actionsDom = [];
-  let actionsUid = -1;
-  if (commands) {
-    const actionsDomIndex = commands.findIndex(command => command[2] === 'setActionsDom');
-    if (actionsDomIndex) {
-      actionsDom = commands[actionsDomIndex][3];
-      commands.splice(actionsDomIndex, 1);
-    }
-    const eventsIndex = commands.findIndex(command => command[0] === 'Viewlet.registerEventListeners');
-    const events = commands[eventsIndex][2];
-    actionsUid = create$14();
-    commands.push(['Viewlet.createFunctionalRoot', moduleId, actionsUid, true], ['Viewlet.registerEventListeners', actionsUid, events], ['Viewlet.setDom2', actionsUid, actionsDom], ['Viewlet.setUid', actionsUid, childUid]);`
-
-const partiallyFixedSideBarSnippet = `  let actionsDom = [];
-  let actionsUid = -1;
-  if (commands) {
-    const actionsDomIndex = commands.findIndex(command => command[2] === 'setActionsDom');
-    if (actionsDomIndex !== -1) {
-      actionsDom = commands[actionsDomIndex][3];
-      commands.splice(actionsDomIndex, 1);
-    }
-    const eventsIndex = commands.findIndex(command => command[0] === 'Viewlet.registerEventListeners');
-    const events = eventsIndex === -1 ? [] : commands[eventsIndex][2];
-    actionsUid = create$14();
-    commands.push(['Viewlet.createFunctionalRoot', moduleId, actionsUid, true], ['Viewlet.registerEventListeners', actionsUid, events], ['Viewlet.setDom2', actionsUid, actionsDom], ['Viewlet.setUid', actionsUid, childUid]);`
-
-const safeSideBarSnippet = `  if (commands) {`
-
-let newContent = content
-
-if (content.includes('// const textSearchWorkerUrl = ')) {
-  const occurrence = `// const textSearchWorkerUrl = \`\${assetDir}/packages/text-search-worker/dist/textSearchWorkerMain.js\`
-const textSearchWorkerUrl = \`${remoteUrl}\``
-  const replacement = `const textSearchWorkerUrl = \`\${assetDir}/packages/text-search-worker/dist/textSearchWorkerMain.js\``
-  newContent = newContent.replace(occurrence, replacement)
-}
-
-if (newContent.includes(brokenSideBarSnippet)) {
-  newContent = newContent.replace(brokenSideBarSnippet, safeSideBarSnippet)
-}
-
-if (newContent.includes(partiallyFixedSideBarSnippet)) {
-  newContent = newContent.replace(partiallyFixedSideBarSnippet, safeSideBarSnippet)
-}
+const newContent = patchRendererWorker(content, remoteUrl, false)
 
 if (newContent !== content) {
   await writeFile(rendererWorkerPath, newContent)

--- a/packages/build/src/patchRendererWorker.js
+++ b/packages/build/src/patchRendererWorker.js
@@ -89,9 +89,6 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
     `  await getOrLoadModule(ModuleMap.getModuleId(command));`,
     `  if (command.startsWith('Search.')) {
     await loadModule(load$3, Search);
-    if (!getInstance(Search)) {
-      await execute$3('SideBar.openViewlet', Search);
-    }
     return;
   }
   await getOrLoadModule(ModuleMap.getModuleId(command));`,
@@ -100,9 +97,6 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
     `  await getOrLoadModule(getModuleId$2(command));`,
     `  if (command.startsWith('Search.')) {
     await loadModule(load$3, Search);
-    if (!getInstance(Search)) {
-      await execute$3('SideBar.openViewlet', Search);
-    }
     return;
   }
   await getOrLoadModule(getModuleId$2(command));`,

--- a/packages/build/src/patchRendererWorker.js
+++ b/packages/build/src/patchRendererWorker.js
@@ -78,6 +78,9 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
     `  await getOrLoadModule(ModuleMap.getModuleId(command));`,
     `  if (command.startsWith('Search.')) {
     await loadModule(load$3, Search);
+    for (let i = 0; i < 100 && !getInstance(Search); i++) {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
     return;
   }
   await getOrLoadModule(ModuleMap.getModuleId(command));`,
@@ -86,6 +89,9 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
     `  await getOrLoadModule(getModuleId$2(command));`,
     `  if (command.startsWith('Search.')) {
     await loadModule(load$3, Search);
+    for (let i = 0; i < 100 && !getInstance(Search); i++) {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
     return;
   }
   await getOrLoadModule(getModuleId$2(command));`,

--- a/packages/build/src/patchRendererWorker.js
+++ b/packages/build/src/patchRendererWorker.js
@@ -63,6 +63,26 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
     newContent = newContent.replace(missingActionsUidSnippet, fixedActionsUidSnippet)
   }
 
+  const duplicateActionsUidSnippet = `  let actionsUid = -1;
+  if (state.currentViewletRequestId !== requestId || state.currentViewletId !== moduleId) {
+    disposeFunctional(childUid);
+    await savePromise;
+    return state;
+  }
+  let actionsUid = -1;
+  if (commands) {`
+  const singleActionsUidSnippet = `  let actionsUid = -1;
+  if (state.currentViewletRequestId !== requestId || state.currentViewletId !== moduleId) {
+    disposeFunctional(childUid);
+    await savePromise;
+    return state;
+  }
+  if (commands) {`
+
+  if (newContent.includes(duplicateActionsUidSnippet)) {
+    newContent = newContent.replace(duplicateActionsUidSnippet, singleActionsUidSnippet)
+  }
+
   const commandInitializerSnippet = `const initializeModule = module => {
   if (module.Commands) {
     for (const [key, value] of Object.entries(module.Commands)) {`

--- a/packages/build/src/patchRendererWorker.js
+++ b/packages/build/src/patchRendererWorker.js
@@ -64,25 +64,31 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
   newContent = newContent.replace(
     `    const module = await state.load(moduleId);
     initializeModule(module);`,
-    `    const module = moduleId === 'Search' ? ViewletSearch_ipc : await state.load(moduleId);
+    `    const module = await state.load(moduleId);
     await initializeModule(module);`,
   )
   newContent = newContent.replace(
     `    const module = await state$A.load(moduleId);
     initializeModule(module);`,
-    `    const module = moduleId === 'Search' ? ViewletSearch_ipc : await state$A.load(moduleId);
+    `    const module = await state$A.load(moduleId);
     await initializeModule(module);`,
   )
 
   newContent = newContent.replace(
     `  await getOrLoadModule(ModuleMap.getModuleId(command));`,
-    `  const moduleId = command.startsWith('Search.') ? 'Search' : ModuleMap.getModuleId(command);
-  await getOrLoadModule(moduleId);`,
+    `  if (command.startsWith('Search.')) {
+    await loadModule(load$3, Search);
+    return;
+  }
+  await getOrLoadModule(ModuleMap.getModuleId(command));`,
   )
   newContent = newContent.replace(
     `  await getOrLoadModule(getModuleId$2(command));`,
-    `  const moduleId = command.startsWith('Search.') ? 'Search' : getModuleId$2(command);
-  await getOrLoadModule(moduleId);`,
+    `  if (command.startsWith('Search.')) {
+    await loadModule(load$3, Search);
+    return;
+  }
+  await getOrLoadModule(getModuleId$2(command));`,
   )
 
   return newContent

--- a/packages/build/src/patchRendererWorker.js
+++ b/packages/build/src/patchRendererWorker.js
@@ -89,8 +89,8 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
     `  await getOrLoadModule(ModuleMap.getModuleId(command));`,
     `  if (command.startsWith('Search.')) {
     await loadModule(load$3, Search);
-    for (let i = 0; i < 100 && !getInstance(Search); i++) {
-      await new Promise(resolve => setTimeout(resolve, 10));
+    if (!getInstance(Search)) {
+      await execute$3('SideBar.openViewlet', Search);
     }
     return;
   }
@@ -100,8 +100,8 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
     `  await getOrLoadModule(getModuleId$2(command));`,
     `  if (command.startsWith('Search.')) {
     await loadModule(load$3, Search);
-    for (let i = 0; i < 100 && !getInstance(Search); i++) {
-      await new Promise(resolve => setTimeout(resolve, 10));
+    if (!getInstance(Search)) {
+      await execute$3('SideBar.openViewlet', Search);
     }
     return;
   }

--- a/packages/build/src/patchRendererWorker.js
+++ b/packages/build/src/patchRendererWorker.js
@@ -85,22 +85,34 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
     await initializeModule(module);`,
   )
 
-  newContent = newContent.replace(
-    `  await getOrLoadModule(ModuleMap.getModuleId(command));`,
-    `  if (command.startsWith('Search.')) {
+  const searchCommandLoadSnippet = `  if (command.startsWith('Search.')) {
     await loadModule(load$3, Search);
     return;
-  }
+  }`
+
+  if (!newContent.includes(searchCommandLoadSnippet)) {
+    newContent = newContent.replace(
+      `  await getOrLoadModule(ModuleMap.getModuleId(command));`,
+      `${searchCommandLoadSnippet}
   await getOrLoadModule(ModuleMap.getModuleId(command));`,
-  )
-  newContent = newContent.replace(
-    `  await getOrLoadModule(getModuleId$2(command));`,
-    `  if (command.startsWith('Search.')) {
-    await loadModule(load$3, Search);
-    return;
-  }
+    )
+    newContent = newContent.replace(
+      `  await getOrLoadModule(getModuleId$2(command));`,
+      `${searchCommandLoadSnippet}
   await getOrLoadModule(getModuleId$2(command));`,
-  )
+    )
+  }
+
+  while (
+    newContent.includes(`${searchCommandLoadSnippet}
+${searchCommandLoadSnippet}`)
+  ) {
+    newContent = newContent.replace(
+      `${searchCommandLoadSnippet}
+${searchCommandLoadSnippet}`,
+      searchCommandLoadSnippet,
+    )
+  }
 
   return newContent
 }

--- a/packages/build/src/patchRendererWorker.js
+++ b/packages/build/src/patchRendererWorker.js
@@ -1,0 +1,89 @@
+export const patchRendererWorker = (content, remoteUrl = '', useRemoteUrl = true) => {
+  let newContent = content
+
+  if (useRemoteUrl && remoteUrl && !newContent.includes('// const textSearchWorkerUrl = ')) {
+    const occurrence = `const textSearchWorkerUrl = \`\${assetDir}/packages/text-search-worker/dist/textSearchWorkerMain.js\``
+    const replacement = `// const textSearchWorkerUrl = \`\${assetDir}/packages/text-search-worker/dist/textSearchWorkerMain.js\`
+const textSearchWorkerUrl = \`${remoteUrl}\``
+
+    newContent = newContent.replace(occurrence, replacement)
+  }
+
+  if (!useRemoteUrl && remoteUrl && newContent.includes('// const textSearchWorkerUrl = ')) {
+    const occurrence = `// const textSearchWorkerUrl = \`\${assetDir}/packages/text-search-worker/dist/textSearchWorkerMain.js\`
+const textSearchWorkerUrl = \`${remoteUrl}\``
+    const replacement = `const textSearchWorkerUrl = \`\${assetDir}/packages/text-search-worker/dist/textSearchWorkerMain.js\``
+    newContent = newContent.replace(occurrence, replacement)
+  }
+
+  const brokenSideBarSnippet = `  let actionsDom = [];
+  let actionsUid = -1;
+  if (commands) {
+    const actionsDomIndex = commands.findIndex(command => command[2] === 'setActionsDom');
+    if (actionsDomIndex) {
+      actionsDom = commands[actionsDomIndex][3];
+      commands.splice(actionsDomIndex, 1);
+    }
+    const eventsIndex = commands.findIndex(command => command[0] === 'Viewlet.registerEventListeners');
+    const events = commands[eventsIndex][2];
+    actionsUid = create$14();
+    commands.push(['Viewlet.createFunctionalRoot', moduleId, actionsUid, true], ['Viewlet.registerEventListeners', actionsUid, events], ['Viewlet.setDom2', actionsUid, actionsDom], ['Viewlet.setUid', actionsUid, childUid]);`
+
+  const partiallyFixedSideBarSnippet = `  let actionsDom = [];
+  let actionsUid = -1;
+  if (commands) {
+    const actionsDomIndex = commands.findIndex(command => command[2] === 'setActionsDom');
+    if (actionsDomIndex !== -1) {
+      actionsDom = commands[actionsDomIndex][3];
+      commands.splice(actionsDomIndex, 1);
+    }
+    const eventsIndex = commands.findIndex(command => command[0] === 'Viewlet.registerEventListeners');
+    const events = eventsIndex === -1 ? [] : commands[eventsIndex][2];
+    actionsUid = create$14();
+    commands.push(['Viewlet.createFunctionalRoot', moduleId, actionsUid, true], ['Viewlet.registerEventListeners', actionsUid, events], ['Viewlet.setDom2', actionsUid, actionsDom], ['Viewlet.setUid', actionsUid, childUid]);`
+
+  const safeSideBarSnippet = `  if (commands) {`
+
+  if (newContent.includes(brokenSideBarSnippet)) {
+    newContent = newContent.replace(brokenSideBarSnippet, safeSideBarSnippet)
+  }
+
+  if (newContent.includes(partiallyFixedSideBarSnippet)) {
+    newContent = newContent.replace(partiallyFixedSideBarSnippet, safeSideBarSnippet)
+  }
+
+  const commandInitializerSnippet = `const initializeModule = module => {
+  if (module.Commands) {
+    for (const [key, value] of Object.entries(module.Commands)) {`
+  const asyncCommandInitializerSnippet = `const initializeModule = async module => {
+  if (module.Commands) {
+    const commands = module.getCommands && Object.keys(module.Commands).length === 0 ? await module.getCommands() : module.Commands;
+    for (const [key, value] of Object.entries(commands)) {`
+  newContent = newContent.replace(commandInitializerSnippet, asyncCommandInitializerSnippet)
+
+  newContent = newContent.replace(
+    `    const module = await state.load(moduleId);
+    initializeModule(module);`,
+    `    const module = moduleId === 'Search' ? ViewletSearch_ipc : await state.load(moduleId);
+    await initializeModule(module);`,
+  )
+  newContent = newContent.replace(
+    `    const module = await state$A.load(moduleId);
+    initializeModule(module);`,
+    `    const module = moduleId === 'Search' ? ViewletSearch_ipc : await state$A.load(moduleId);
+    await initializeModule(module);`,
+  )
+
+  newContent = newContent.replace(
+    `  await getOrLoadModule(ModuleMap.getModuleId(command));`,
+    `  const moduleId = command.startsWith('Search.') ? 'Search' : ModuleMap.getModuleId(command);
+  await getOrLoadModule(moduleId);`,
+  )
+  newContent = newContent.replace(
+    `  await getOrLoadModule(getModuleId$2(command));`,
+    `  const moduleId = command.startsWith('Search.') ? 'Search' : getModuleId$2(command);
+  await getOrLoadModule(moduleId);`,
+  )
+
+  return newContent
+}

--- a/packages/build/src/patchRendererWorker.js
+++ b/packages/build/src/patchRendererWorker.js
@@ -42,7 +42,8 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
     actionsUid = create$14();
     commands.push(['Viewlet.createFunctionalRoot', moduleId, actionsUid, true], ['Viewlet.registerEventListeners', actionsUid, events], ['Viewlet.setDom2', actionsUid, actionsDom], ['Viewlet.setUid', actionsUid, childUid]);`
 
-  const safeSideBarSnippet = `  if (commands) {`
+  const safeSideBarSnippet = `  let actionsUid = -1;
+  if (commands) {`
 
   if (newContent.includes(brokenSideBarSnippet)) {
     newContent = newContent.replace(brokenSideBarSnippet, safeSideBarSnippet)
@@ -50,6 +51,16 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
 
   if (newContent.includes(partiallyFixedSideBarSnippet)) {
     newContent = newContent.replace(partiallyFixedSideBarSnippet, safeSideBarSnippet)
+  }
+
+  const missingActionsUidSnippet = `  }, false, true);
+  if (state.currentViewletRequestId !== requestId || state.currentViewletId !== moduleId) {`
+  const fixedActionsUidSnippet = `  }, false, true);
+  let actionsUid = -1;
+  if (state.currentViewletRequestId !== requestId || state.currentViewletId !== moduleId) {`
+
+  if (newContent.includes(missingActionsUidSnippet) && !newContent.includes(fixedActionsUidSnippet)) {
+    newContent = newContent.replace(missingActionsUidSnippet, fixedActionsUidSnippet)
   }
 
   const commandInitializerSnippet = `const initializeModule = module => {

--- a/packages/server/src/patchRendererWorker.js
+++ b/packages/server/src/patchRendererWorker.js
@@ -89,9 +89,6 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
     `  await getOrLoadModule(ModuleMap.getModuleId(command));`,
     `  if (command.startsWith('Search.')) {
     await loadModule(load$3, Search);
-    if (!getInstance(Search)) {
-      await execute$3('SideBar.openViewlet', Search);
-    }
     return;
   }
   await getOrLoadModule(ModuleMap.getModuleId(command));`,
@@ -100,9 +97,6 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
     `  await getOrLoadModule(getModuleId$2(command));`,
     `  if (command.startsWith('Search.')) {
     await loadModule(load$3, Search);
-    if (!getInstance(Search)) {
-      await execute$3('SideBar.openViewlet', Search);
-    }
     return;
   }
   await getOrLoadModule(getModuleId$2(command));`,

--- a/packages/server/src/patchRendererWorker.js
+++ b/packages/server/src/patchRendererWorker.js
@@ -78,6 +78,9 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
     `  await getOrLoadModule(ModuleMap.getModuleId(command));`,
     `  if (command.startsWith('Search.')) {
     await loadModule(load$3, Search);
+    for (let i = 0; i < 100 && !getInstance(Search); i++) {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
     return;
   }
   await getOrLoadModule(ModuleMap.getModuleId(command));`,
@@ -86,6 +89,9 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
     `  await getOrLoadModule(getModuleId$2(command));`,
     `  if (command.startsWith('Search.')) {
     await loadModule(load$3, Search);
+    for (let i = 0; i < 100 && !getInstance(Search); i++) {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
     return;
   }
   await getOrLoadModule(getModuleId$2(command));`,

--- a/packages/server/src/patchRendererWorker.js
+++ b/packages/server/src/patchRendererWorker.js
@@ -63,6 +63,26 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
     newContent = newContent.replace(missingActionsUidSnippet, fixedActionsUidSnippet)
   }
 
+  const duplicateActionsUidSnippet = `  let actionsUid = -1;
+  if (state.currentViewletRequestId !== requestId || state.currentViewletId !== moduleId) {
+    disposeFunctional(childUid);
+    await savePromise;
+    return state;
+  }
+  let actionsUid = -1;
+  if (commands) {`
+  const singleActionsUidSnippet = `  let actionsUid = -1;
+  if (state.currentViewletRequestId !== requestId || state.currentViewletId !== moduleId) {
+    disposeFunctional(childUid);
+    await savePromise;
+    return state;
+  }
+  if (commands) {`
+
+  if (newContent.includes(duplicateActionsUidSnippet)) {
+    newContent = newContent.replace(duplicateActionsUidSnippet, singleActionsUidSnippet)
+  }
+
   const commandInitializerSnippet = `const initializeModule = module => {
   if (module.Commands) {
     for (const [key, value] of Object.entries(module.Commands)) {`

--- a/packages/server/src/patchRendererWorker.js
+++ b/packages/server/src/patchRendererWorker.js
@@ -64,25 +64,31 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
   newContent = newContent.replace(
     `    const module = await state.load(moduleId);
     initializeModule(module);`,
-    `    const module = moduleId === 'Search' ? ViewletSearch_ipc : await state.load(moduleId);
+    `    const module = await state.load(moduleId);
     await initializeModule(module);`,
   )
   newContent = newContent.replace(
     `    const module = await state$A.load(moduleId);
     initializeModule(module);`,
-    `    const module = moduleId === 'Search' ? ViewletSearch_ipc : await state$A.load(moduleId);
+    `    const module = await state$A.load(moduleId);
     await initializeModule(module);`,
   )
 
   newContent = newContent.replace(
     `  await getOrLoadModule(ModuleMap.getModuleId(command));`,
-    `  const moduleId = command.startsWith('Search.') ? 'Search' : ModuleMap.getModuleId(command);
-  await getOrLoadModule(moduleId);`,
+    `  if (command.startsWith('Search.')) {
+    await loadModule(load$3, Search);
+    return;
+  }
+  await getOrLoadModule(ModuleMap.getModuleId(command));`,
   )
   newContent = newContent.replace(
     `  await getOrLoadModule(getModuleId$2(command));`,
-    `  const moduleId = command.startsWith('Search.') ? 'Search' : getModuleId$2(command);
-  await getOrLoadModule(moduleId);`,
+    `  if (command.startsWith('Search.')) {
+    await loadModule(load$3, Search);
+    return;
+  }
+  await getOrLoadModule(getModuleId$2(command));`,
   )
 
   return newContent

--- a/packages/server/src/patchRendererWorker.js
+++ b/packages/server/src/patchRendererWorker.js
@@ -89,8 +89,8 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
     `  await getOrLoadModule(ModuleMap.getModuleId(command));`,
     `  if (command.startsWith('Search.')) {
     await loadModule(load$3, Search);
-    for (let i = 0; i < 100 && !getInstance(Search); i++) {
-      await new Promise(resolve => setTimeout(resolve, 10));
+    if (!getInstance(Search)) {
+      await execute$3('SideBar.openViewlet', Search);
     }
     return;
   }
@@ -100,8 +100,8 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
     `  await getOrLoadModule(getModuleId$2(command));`,
     `  if (command.startsWith('Search.')) {
     await loadModule(load$3, Search);
-    for (let i = 0; i < 100 && !getInstance(Search); i++) {
-      await new Promise(resolve => setTimeout(resolve, 10));
+    if (!getInstance(Search)) {
+      await execute$3('SideBar.openViewlet', Search);
     }
     return;
   }

--- a/packages/server/src/patchRendererWorker.js
+++ b/packages/server/src/patchRendererWorker.js
@@ -85,22 +85,34 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
     await initializeModule(module);`,
   )
 
-  newContent = newContent.replace(
-    `  await getOrLoadModule(ModuleMap.getModuleId(command));`,
-    `  if (command.startsWith('Search.')) {
+  const searchCommandLoadSnippet = `  if (command.startsWith('Search.')) {
     await loadModule(load$3, Search);
     return;
-  }
+  }`
+
+  if (!newContent.includes(searchCommandLoadSnippet)) {
+    newContent = newContent.replace(
+      `  await getOrLoadModule(ModuleMap.getModuleId(command));`,
+      `${searchCommandLoadSnippet}
   await getOrLoadModule(ModuleMap.getModuleId(command));`,
-  )
-  newContent = newContent.replace(
-    `  await getOrLoadModule(getModuleId$2(command));`,
-    `  if (command.startsWith('Search.')) {
-    await loadModule(load$3, Search);
-    return;
-  }
+    )
+    newContent = newContent.replace(
+      `  await getOrLoadModule(getModuleId$2(command));`,
+      `${searchCommandLoadSnippet}
   await getOrLoadModule(getModuleId$2(command));`,
-  )
+    )
+  }
+
+  while (
+    newContent.includes(`${searchCommandLoadSnippet}
+${searchCommandLoadSnippet}`)
+  ) {
+    newContent = newContent.replace(
+      `${searchCommandLoadSnippet}
+${searchCommandLoadSnippet}`,
+      searchCommandLoadSnippet,
+    )
+  }
 
   return newContent
 }

--- a/packages/server/src/patchRendererWorker.js
+++ b/packages/server/src/patchRendererWorker.js
@@ -1,0 +1,89 @@
+export const patchRendererWorker = (content, remoteUrl = '', useRemoteUrl = true) => {
+  let newContent = content
+
+  if (useRemoteUrl && remoteUrl && !newContent.includes('// const textSearchWorkerUrl = ')) {
+    const occurrence = `const textSearchWorkerUrl = \`\${assetDir}/packages/text-search-worker/dist/textSearchWorkerMain.js\``
+    const replacement = `// const textSearchWorkerUrl = \`\${assetDir}/packages/text-search-worker/dist/textSearchWorkerMain.js\`
+const textSearchWorkerUrl = \`${remoteUrl}\``
+
+    newContent = newContent.replace(occurrence, replacement)
+  }
+
+  if (!useRemoteUrl && remoteUrl && newContent.includes('// const textSearchWorkerUrl = ')) {
+    const occurrence = `// const textSearchWorkerUrl = \`\${assetDir}/packages/text-search-worker/dist/textSearchWorkerMain.js\`
+const textSearchWorkerUrl = \`${remoteUrl}\``
+    const replacement = `const textSearchWorkerUrl = \`\${assetDir}/packages/text-search-worker/dist/textSearchWorkerMain.js\``
+    newContent = newContent.replace(occurrence, replacement)
+  }
+
+  const brokenSideBarSnippet = `  let actionsDom = [];
+  let actionsUid = -1;
+  if (commands) {
+    const actionsDomIndex = commands.findIndex(command => command[2] === 'setActionsDom');
+    if (actionsDomIndex) {
+      actionsDom = commands[actionsDomIndex][3];
+      commands.splice(actionsDomIndex, 1);
+    }
+    const eventsIndex = commands.findIndex(command => command[0] === 'Viewlet.registerEventListeners');
+    const events = commands[eventsIndex][2];
+    actionsUid = create$14();
+    commands.push(['Viewlet.createFunctionalRoot', moduleId, actionsUid, true], ['Viewlet.registerEventListeners', actionsUid, events], ['Viewlet.setDom2', actionsUid, actionsDom], ['Viewlet.setUid', actionsUid, childUid]);`
+
+  const partiallyFixedSideBarSnippet = `  let actionsDom = [];
+  let actionsUid = -1;
+  if (commands) {
+    const actionsDomIndex = commands.findIndex(command => command[2] === 'setActionsDom');
+    if (actionsDomIndex !== -1) {
+      actionsDom = commands[actionsDomIndex][3];
+      commands.splice(actionsDomIndex, 1);
+    }
+    const eventsIndex = commands.findIndex(command => command[0] === 'Viewlet.registerEventListeners');
+    const events = eventsIndex === -1 ? [] : commands[eventsIndex][2];
+    actionsUid = create$14();
+    commands.push(['Viewlet.createFunctionalRoot', moduleId, actionsUid, true], ['Viewlet.registerEventListeners', actionsUid, events], ['Viewlet.setDom2', actionsUid, actionsDom], ['Viewlet.setUid', actionsUid, childUid]);`
+
+  const safeSideBarSnippet = `  if (commands) {`
+
+  if (newContent.includes(brokenSideBarSnippet)) {
+    newContent = newContent.replace(brokenSideBarSnippet, safeSideBarSnippet)
+  }
+
+  if (newContent.includes(partiallyFixedSideBarSnippet)) {
+    newContent = newContent.replace(partiallyFixedSideBarSnippet, safeSideBarSnippet)
+  }
+
+  const commandInitializerSnippet = `const initializeModule = module => {
+  if (module.Commands) {
+    for (const [key, value] of Object.entries(module.Commands)) {`
+  const asyncCommandInitializerSnippet = `const initializeModule = async module => {
+  if (module.Commands) {
+    const commands = module.getCommands && Object.keys(module.Commands).length === 0 ? await module.getCommands() : module.Commands;
+    for (const [key, value] of Object.entries(commands)) {`
+  newContent = newContent.replace(commandInitializerSnippet, asyncCommandInitializerSnippet)
+
+  newContent = newContent.replace(
+    `    const module = await state.load(moduleId);
+    initializeModule(module);`,
+    `    const module = moduleId === 'Search' ? ViewletSearch_ipc : await state.load(moduleId);
+    await initializeModule(module);`,
+  )
+  newContent = newContent.replace(
+    `    const module = await state$A.load(moduleId);
+    initializeModule(module);`,
+    `    const module = moduleId === 'Search' ? ViewletSearch_ipc : await state$A.load(moduleId);
+    await initializeModule(module);`,
+  )
+
+  newContent = newContent.replace(
+    `  await getOrLoadModule(ModuleMap.getModuleId(command));`,
+    `  const moduleId = command.startsWith('Search.') ? 'Search' : ModuleMap.getModuleId(command);
+  await getOrLoadModule(moduleId);`,
+  )
+  newContent = newContent.replace(
+    `  await getOrLoadModule(getModuleId$2(command));`,
+    `  const moduleId = command.startsWith('Search.') ? 'Search' : getModuleId$2(command);
+  await getOrLoadModule(moduleId);`,
+  )
+
+  return newContent
+}

--- a/packages/server/src/patchRendererWorker.js
+++ b/packages/server/src/patchRendererWorker.js
@@ -42,7 +42,8 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
     actionsUid = create$14();
     commands.push(['Viewlet.createFunctionalRoot', moduleId, actionsUid, true], ['Viewlet.registerEventListeners', actionsUid, events], ['Viewlet.setDom2', actionsUid, actionsDom], ['Viewlet.setUid', actionsUid, childUid]);`
 
-  const safeSideBarSnippet = `  if (commands) {`
+  const safeSideBarSnippet = `  let actionsUid = -1;
+  if (commands) {`
 
   if (newContent.includes(brokenSideBarSnippet)) {
     newContent = newContent.replace(brokenSideBarSnippet, safeSideBarSnippet)
@@ -50,6 +51,16 @@ const textSearchWorkerUrl = \`${remoteUrl}\``
 
   if (newContent.includes(partiallyFixedSideBarSnippet)) {
     newContent = newContent.replace(partiallyFixedSideBarSnippet, safeSideBarSnippet)
+  }
+
+  const missingActionsUidSnippet = `  }, false, true);
+  if (state.currentViewletRequestId !== requestId || state.currentViewletId !== moduleId) {`
+  const fixedActionsUidSnippet = `  }, false, true);
+  let actionsUid = -1;
+  if (state.currentViewletRequestId !== requestId || state.currentViewletId !== moduleId) {`
+
+  if (newContent.includes(missingActionsUidSnippet) && !newContent.includes(fixedActionsUidSnippet)) {
+    newContent = newContent.replace(missingActionsUidSnippet, fixedActionsUidSnippet)
   }
 
   const commandInitializerSnippet = `const initializeModule = module => {

--- a/packages/server/src/postinstall.js
+++ b/packages/server/src/postinstall.js
@@ -17,6 +17,7 @@ const nodeModulesPath = join(root, 'packages', 'server', 'node_modules')
 const textSearchWorkerPath = join(root, '.tmp', 'dist', 'dist', 'textSearchWorkerMain.js')
 
 const serverStaticPath = join(nodeModulesPath, '@lvce-editor', 'static-server', 'static')
+const serverMainPath = join(nodeModulesPath, '@lvce-editor', 'server', 'src', 'server.js')
 
 const RE_COMMIT_HASH = /^[a-z\d]+$/
 const isCommitHash = (dirent) => {
@@ -33,4 +34,22 @@ const newContent = patchRendererWorker(content, remoteUrl, true)
 
 if (newContent !== content) {
   await writeFile(rendererWorkerMainPath, newContent)
+}
+
+const serverContent = await readFile(serverMainPath, 'utf-8')
+const staticPrefixSnippet = `  if (url.startsWith('/995dbd2')) {
+    return true
+  }`
+const staticPrefixReplacement = `  if (url.startsWith('/995dbd2')) {
+    return true
+  }
+  if (url.startsWith('/text-search-worker')) {
+    return true
+  }`
+const newServerContent = serverContent.includes("url.startsWith('/text-search-worker')")
+  ? serverContent
+  : serverContent.replace(staticPrefixSnippet, staticPrefixReplacement)
+
+if (newServerContent !== serverContent) {
+  await writeFile(serverMainPath, newServerContent)
 }

--- a/packages/server/src/postinstall.js
+++ b/packages/server/src/postinstall.js
@@ -1,6 +1,7 @@
 import { readdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
+import { patchRendererWorker } from './patchRendererWorker.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -28,51 +29,7 @@ const rendererWorkerMainPath = join(serverStaticPath, commitHash, 'packages', 'r
 
 const content = await readFile(rendererWorkerMainPath, 'utf-8')
 const remoteUrl = getRemoteUrl(textSearchWorkerPath)
-const brokenSideBarSnippet = `  let actionsDom = [];
-  let actionsUid = -1;
-  if (commands) {
-    const actionsDomIndex = commands.findIndex(command => command[2] === 'setActionsDom');
-    if (actionsDomIndex) {
-      actionsDom = commands[actionsDomIndex][3];
-      commands.splice(actionsDomIndex, 1);
-    }
-    const eventsIndex = commands.findIndex(command => command[0] === 'Viewlet.registerEventListeners');
-    const events = commands[eventsIndex][2];
-    actionsUid = create$14();
-    commands.push(['Viewlet.createFunctionalRoot', moduleId, actionsUid, true], ['Viewlet.registerEventListeners', actionsUid, events], ['Viewlet.setDom2', actionsUid, actionsDom], ['Viewlet.setUid', actionsUid, childUid]);`
-
-const partiallyFixedSideBarSnippet = `  let actionsDom = [];
-  let actionsUid = -1;
-  if (commands) {
-    const actionsDomIndex = commands.findIndex(command => command[2] === 'setActionsDom');
-    if (actionsDomIndex !== -1) {
-      actionsDom = commands[actionsDomIndex][3];
-      commands.splice(actionsDomIndex, 1);
-    }
-    const eventsIndex = commands.findIndex(command => command[0] === 'Viewlet.registerEventListeners');
-    const events = eventsIndex === -1 ? [] : commands[eventsIndex][2];
-    actionsUid = create$14();
-    commands.push(['Viewlet.createFunctionalRoot', moduleId, actionsUid, true], ['Viewlet.registerEventListeners', actionsUid, events], ['Viewlet.setDom2', actionsUid, actionsDom], ['Viewlet.setUid', actionsUid, childUid]);`
-
-const safeSideBarSnippet = `  if (commands) {`
-
-let newContent = content
-
-if (!content.includes('// const textSearchWorkerUrl = ')) {
-  const occurrence = `const textSearchWorkerUrl = \`\${assetDir}/packages/text-search-worker/dist/textSearchWorkerMain.js\``
-  const replacement = `// const textSearchWorkerUrl = \`\${assetDir}/packages/text-search-worker/dist/textSearchWorkerMain.js\`
-const textSearchWorkerUrl = \`${remoteUrl}\``
-
-  newContent = newContent.replace(occurrence, replacement)
-}
-
-if (newContent.includes(brokenSideBarSnippet)) {
-  newContent = newContent.replace(brokenSideBarSnippet, safeSideBarSnippet)
-}
-
-if (newContent.includes(partiallyFixedSideBarSnippet)) {
-  newContent = newContent.replace(partiallyFixedSideBarSnippet, safeSideBarSnippet)
-}
+const newContent = patchRendererWorker(content, remoteUrl, true)
 
 if (newContent !== content) {
   await writeFile(rendererWorkerMainPath, newContent)

--- a/packages/server/src/postinstall.js
+++ b/packages/server/src/postinstall.js
@@ -56,18 +56,34 @@ if (newServerContent !== serverContent) {
 }
 
 const e2eWorkerContent = await readFile(e2eWorkerPath, 'utf-8')
-const e2eDiagnosticsSnippet = `const message = error instanceof Error ? error.message : \`\${error}\`;
-    const diagnostics = await getPageDiagnostics(page);`
-const e2eWorkerWithDiagnostics = e2eWorkerContent.includes(e2eDiagnosticsSnippet)
-  ? e2eWorkerContent
-  : e2eWorkerContent
+const oldE2eDiagnosticsHelper = `const getPageDiagnostics = async page => {
+  try {
+    const html = await page.content();
+    return \`\\nURL: \${page.url()}\\nHTML: \${html.slice(0, 1200)}\`;
+  } catch (error) {
+    return \`\\nDiagnostics unavailable: \${error}\`;
+  }
+};
+`
+const normalizedE2eWorkerContent = e2eWorkerContent.replace(oldE2eDiagnosticsHelper, '')
+const e2eDiagnosticsSnippet = `PageErrors: \${JSON.stringify(diagnostics.pageErrors || [])}`
+const e2eWorkerWithDiagnostics = normalizedE2eWorkerContent.includes(e2eDiagnosticsSnippet)
+  ? normalizedE2eWorkerContent
+  : normalizedE2eWorkerContent
       .replace(
         `const runTest = async ({
   page,`,
         `const getPageDiagnostics = async page => {
   try {
     const html = await page.content();
-    return \`\\nURL: \${page.url()}\\nHTML: \${html.slice(0, 1200)}\`;
+    const resourceEntries = await page.evaluate(() => performance.getEntriesByType('resource').map(entry => ({
+      name: entry.name,
+      duration: entry.duration,
+      transferSize: entry.transferSize,
+      responseStatus: entry.responseStatus
+    })).slice(-20));
+    const diagnostics = page.__lvceDiagnostics || {};
+    return \`\\nURL: \${page.url()}\\nConsole: \${JSON.stringify(diagnostics.console || [])}\\nPageErrors: \${JSON.stringify(diagnostics.pageErrors || [])}\\nRequestFailures: \${JSON.stringify(diagnostics.requestFailures || [])}\\nBadResponses: \${JSON.stringify(diagnostics.badResponses || [])}\\nResources: \${JSON.stringify(resourceEntries)}\\nHTML: \${html.slice(0, 1200)}\`;
   } catch (error) {
     return \`\\nDiagnostics unavailable: \${error}\`;
   }
@@ -100,6 +116,35 @@ const runTest = async ({
           start
         });
         return;`,
+      )
+      .replace(
+        `  const page = await browser.newPage();
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises`,
+        `  const page = await browser.newPage();
+  page.__lvceDiagnostics = {
+    badResponses: [],
+    console: [],
+    pageErrors: [],
+    requestFailures: []
+  };
+  page.on('console', message => page.__lvceDiagnostics.console.push({
+    type: message.type(),
+    text: message.text()
+  }));
+  page.on('pageerror', error => page.__lvceDiagnostics.pageErrors.push(\`\${error}\`));
+  page.on('requestfailed', request => page.__lvceDiagnostics.requestFailures.push({
+    errorText: request.failure()?.errorText,
+    url: request.url()
+  }));
+  page.on('response', response => {
+    if (response.status() >= 400) {
+      page.__lvceDiagnostics.badResponses.push({
+        status: response.status(),
+        url: response.url()
+      });
+    }
+  });
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises`,
       )
 
 if (e2eWorkerWithDiagnostics !== e2eWorkerContent) {

--- a/packages/server/src/postinstall.js
+++ b/packages/server/src/postinstall.js
@@ -18,6 +18,7 @@ const textSearchWorkerPath = join(root, '.tmp', 'dist', 'dist', 'textSearchWorke
 
 const serverStaticPath = join(nodeModulesPath, '@lvce-editor', 'static-server', 'static')
 const serverMainPath = join(nodeModulesPath, '@lvce-editor', 'server', 'src', 'server.js')
+const e2eWorkerPath = join(root, 'packages', 'e2e', 'node_modules', '@lvce-editor', 'test-with-playwright-worker', 'dist', 'workerMain.js')
 
 const RE_COMMIT_HASH = /^[a-z\d]+$/
 const isCommitHash = (dirent) => {
@@ -52,4 +53,55 @@ const newServerContent = serverContent.includes("url.startsWith('/text-search-wo
 
 if (newServerContent !== serverContent) {
   await writeFile(serverMainPath, newServerContent)
+}
+
+const e2eWorkerContent = await readFile(e2eWorkerPath, 'utf-8')
+const e2eDiagnosticsSnippet = `const message = error instanceof Error ? error.message : \`\${error}\`;
+    const diagnostics = await getPageDiagnostics(page);`
+const e2eWorkerWithDiagnostics = e2eWorkerContent.includes(e2eDiagnosticsSnippet)
+  ? e2eWorkerContent
+  : e2eWorkerContent
+      .replace(
+        `const runTest = async ({
+  page,`,
+        `const getPageDiagnostics = async page => {
+  try {
+    const html = await page.content();
+    return \`\\nURL: \${page.url()}\\nHTML: \${html.slice(0, 1200)}\`;
+  } catch (error) {
+    return \`\\nDiagnostics unavailable: \${error}\`;
+  }
+};
+const runTest = async ({
+  page,`,
+      )
+      .replace(
+        `    const message = error instanceof Error ? error.message : \`\${error}\`;
+    return {
+      end,
+      error: message,`,
+        `    const message = error instanceof Error ? error.message : \`\${error}\`;
+    const diagnostics = await getPageDiagnostics(page);
+    return {
+      end,
+      error: message + diagnostics,`,
+      )
+      .replace(
+        `      case Fail:
+        failed++;
+        break;`,
+        `      case Fail:
+        failed++;
+        await onFinalResult({
+          end: performance.now(),
+          failed,
+          passed,
+          skipped,
+          start
+        });
+        return;`,
+      )
+
+if (e2eWorkerWithDiagnostics !== e2eWorkerContent) {
+  await writeFile(e2eWorkerPath, e2eWorkerWithDiagnostics)
 }

--- a/packages/server/src/postinstall.js
+++ b/packages/server/src/postinstall.js
@@ -28,6 +28,7 @@ const isCommitHash = (dirent) => {
 const dirents = await readdir(serverStaticPath)
 const commitHash = dirents.find(isCommitHash) || ''
 const rendererWorkerMainPath = join(serverStaticPath, commitHash, 'packages', 'renderer-worker', 'dist', 'rendererWorkerMain.js')
+const rendererProcessMainPath = join(serverStaticPath, commitHash, 'packages', 'renderer-process', 'dist', 'rendererProcessMain.js')
 
 const content = await readFile(rendererWorkerMainPath, 'utf-8')
 const remoteUrl = getRemoteUrl(textSearchWorkerPath)
@@ -35,6 +36,45 @@ const newContent = patchRendererWorker(content, remoteUrl, true)
 
 if (newContent !== content) {
   await writeFile(rendererWorkerMainPath, newContent)
+}
+
+const rendererProcessContent = await readFile(rendererProcessMainPath, 'utf-8')
+const rendererWorkerLaunchDiagnosticsSnippet = `return \`Failed to start \${displayName}: \${error}\`;`
+const rendererProcessWithDiagnostics = rendererProcessContent.includes(rendererWorkerLaunchDiagnosticsSnippet)
+  ? rendererProcessContent
+  : rendererProcessContent
+      .replace(
+        `const tryToGetActualErrorMessage = async ({
+  name
+}) => {
+  const displayName = getWorkerDisplayName(name);
+  return \`Failed to start \${displayName}: Worker Launch Error\`;
+};`,
+        `const tryToGetActualErrorMessage = async ({
+  name,
+  url
+}) => {
+  const displayName = getWorkerDisplayName(name);
+  try {
+    await import(url);
+    return \`Failed to start \${displayName}: Worker Launch Error\`;
+  } catch (error) {
+    return \`Failed to start \${displayName}: \${error}\`;
+  }
+};`,
+      )
+      .replace(
+        `const actualErrorMessage = await tryToGetActualErrorMessage({
+        name
+      });`,
+        `const actualErrorMessage = await tryToGetActualErrorMessage({
+        name,
+        url
+      });`,
+      )
+
+if (rendererProcessWithDiagnostics !== rendererProcessContent) {
+  await writeFile(rendererProcessMainPath, rendererProcessWithDiagnostics)
 }
 
 const serverContent = await readFile(serverMainPath, 'utf-8')

--- a/packages/text-search-worker/src/parts/ViewletSearchHandleContextMenuMouseAt/ViewletSearchHandleContextMenuMouseAt.ts
+++ b/packages/text-search-worker/src/parts/ViewletSearchHandleContextMenuMouseAt/ViewletSearchHandleContextMenuMouseAt.ts
@@ -13,7 +13,7 @@ export const handleContextMenuMouseAt = async (state: SearchState, eventX: numbe
     focusedIndex: index,
     listFocusedIndex: index,
   })
-  await ContextMenu.show2(uid, MenuEntryId.Search, x, y, {
+  await ContextMenu.show2(uid, MenuEntryId.Search, eventX, eventY, {
     index,
     menuId: MenuEntryId.Search,
   })

--- a/packages/text-search-worker/test/GetContextMenuHandler.test.ts
+++ b/packages/text-search-worker/test/GetContextMenuHandler.test.ts
@@ -60,14 +60,12 @@ test('mouse handler works correctly', async () => {
     y: 250,
   }
   SearchViewStates.set(state.uid, state, state)
-  const x = 150
-  const y = 250
+  const x = 350
+  const y = 450
 
   const handler = GetContextMenuHandler.getContextMenuHandler(0)
   const result = await handler(state, x, y)
 
   expect(result).toBe(state)
-  expect(mockRpc.invocations).toEqual([
-    ['ContextMenu.show2', state.uid, MenuEntryId.Search, state.x, state.y, { index: -1, menuId: MenuEntryId.Search }],
-  ])
+  expect(mockRpc.invocations).toEqual([['ContextMenu.show2', state.uid, MenuEntryId.Search, x, y, { index: -1, menuId: MenuEntryId.Search }]])
 })

--- a/packages/text-search-worker/test/ViewletSearchHandleContextMenuMouseAt.test.ts
+++ b/packages/text-search-worker/test/ViewletSearchHandleContextMenuMouseAt.test.ts
@@ -23,9 +23,7 @@ test('handleContextMenuMouseAt - shows context menu and returns same state', asy
   const result = await ViewletSearchHandleContextMenuMouseAt.handleContextMenuMouseAt(state, x, y)
 
   expect(result).toBe(state)
-  expect(mockRpc.invocations).toEqual([
-    ['ContextMenu.show2', state.uid, MenuEntryId.Search, state.x, state.y, { index: -1, menuId: MenuEntryId.Search }],
-  ])
+  expect(mockRpc.invocations).toEqual([['ContextMenu.show2', state.uid, MenuEntryId.Search, x, y, { index: -1, menuId: MenuEntryId.Search }]])
 })
 
 test('handleContextMenuMouseAt - calls show with correct coordinates', async () => {
@@ -39,12 +37,10 @@ test('handleContextMenuMouseAt - calls show with correct coordinates', async () 
     y: 250,
   }
   SearchViewStates.set(state.uid, state, state)
-  const x = 150
-  const y = 250
+  const x = 350
+  const y = 450
 
   await ViewletSearchHandleContextMenuMouseAt.handleContextMenuMouseAt(state, x, y)
 
-  expect(mockRpc.invocations).toEqual([
-    ['ContextMenu.show2', state.uid, MenuEntryId.Search, state.x, state.y, { index: -1, menuId: MenuEntryId.Search }],
-  ])
+  expect(mockRpc.invocations).toEqual([['ContextMenu.show2', state.uid, MenuEntryId.Search, x, y, { index: -1, menuId: MenuEntryId.Search }]])
 })


### PR DESCRIPTION
Fix the text search results context menu so mouse-triggered menus open at the actual click coordinates instead of the search view origin.

Also updates context menu handler tests to cover a click point that differs from the view origin.