### PR TITLE
chore: remove temporary e2e diagnostics

### DIFF
--- a/packages/build/src/build-static.js
+++ b/packages/build/src/build-static.js
@@ -18,7 +18,6 @@ const { commitHash } = await sharedProcess.exportStatic({
 })
 
 const rendererWorkerPath = join(root, 'dist', commitHash, 'packages', 'renderer-worker', 'dist', 'rendererWorkerMain.js')
-const rendererProcessPath = join(root, 'dist', commitHash, 'packages', 'renderer-process', 'dist', 'rendererProcessMain.js')
 
 export const getRemoteUrl = (path) => {
   const url = pathToFileURL(path).toString().slice(8)
@@ -34,49 +33,9 @@ if (newContent !== content) {
   await writeFile(rendererWorkerPath, newContent)
 }
 
-const rendererProcessContent = await readFile(rendererProcessPath, 'utf-8')
-const rendererWorkerLaunchDiagnosticsSnippet = `return \`Failed to start \${displayName}: \${error}\`;`
-const rendererProcessWithDiagnostics = rendererProcessContent.includes(rendererWorkerLaunchDiagnosticsSnippet)
-  ? rendererProcessContent
-  : rendererProcessContent
-      .replace(
-        `const tryToGetActualErrorMessage = async ({
-  name
-}) => {
-  const displayName = getWorkerDisplayName(name);
-  return \`Failed to start \${displayName}: Worker Launch Error\`;
-};`,
-        `const tryToGetActualErrorMessage = async ({
-  name,
-  url
-}) => {
-  const displayName = getWorkerDisplayName(name);
-  try {
-    await import(url);
-    return \`Failed to start \${displayName}: Worker Launch Error\`;
-  } catch (error) {
-    return \`Failed to start \${displayName}: \${error}\`;
-  }
-};`,
-      )
-      .replace(
-        `const actualErrorMessage = await tryToGetActualErrorMessage({
-        name
-      });`,
-        `const actualErrorMessage = await tryToGetActualErrorMessage({
-        name,
-        url
-      });`,
-      )
-
-if (rendererProcessWithDiagnostics !== rendererProcessContent) {
-  await writeFile(rendererProcessPath, rendererProcessWithDiagnostics)
-}
-
 const staticPath = join(root, '.tmp', 'static')
 const staticPrefixPath = join(staticPath, 'text-search-worker')
 const serverMainPath = join(root, 'packages', 'server', 'node_modules', '@lvce-editor', 'server', 'src', 'server.js')
-const e2eWorkerPath = join(root, 'packages', 'e2e', 'node_modules', '@lvce-editor', 'test-with-playwright-worker', 'dist', 'workerMain.js')
 
 const patchServerStaticPrefix = async () => {
   const content = await readFile(serverMainPath, 'utf-8')
@@ -96,107 +55,8 @@ const patchServerStaticPrefix = async () => {
   }
 }
 
-const patchE2eDiagnostics = async () => {
-  const content = await readFile(e2eWorkerPath, 'utf-8')
-  const oldDiagnosticsHelper = `const getPageDiagnostics = async page => {
-  try {
-    const html = await page.content();
-    return \`\\nURL: \${page.url()}\\nHTML: \${html.slice(0, 1200)}\`;
-  } catch (error) {
-    return \`\\nDiagnostics unavailable: \${error}\`;
-  }
-};
-`
-  const normalizedContent = content.replace(oldDiagnosticsHelper, '')
-  const diagnosticsSnippet = `PageErrors: \${JSON.stringify(diagnostics.pageErrors || [])}`
-  const newContent = normalizedContent.includes(diagnosticsSnippet)
-    ? normalizedContent
-    : normalizedContent
-        .replace(
-          `const runTest = async ({
-  page,`,
-          `const getPageDiagnostics = async page => {
-  try {
-    const html = await page.content();
-    const resourceEntries = await page.evaluate(() => performance.getEntriesByType('resource').map(entry => ({
-      name: entry.name,
-      duration: entry.duration,
-      transferSize: entry.transferSize,
-      responseStatus: entry.responseStatus
-    })).slice(-20));
-    const diagnostics = page.__lvceDiagnostics || {};
-    return \`\\nURL: \${page.url()}\\nConsole: \${JSON.stringify(diagnostics.console || [])}\\nPageErrors: \${JSON.stringify(diagnostics.pageErrors || [])}\\nRequestFailures: \${JSON.stringify(diagnostics.requestFailures || [])}\\nBadResponses: \${JSON.stringify(diagnostics.badResponses || [])}\\nResources: \${JSON.stringify(resourceEntries)}\\nHTML: \${html.slice(0, 1200)}\`;
-  } catch (error) {
-    return \`\\nDiagnostics unavailable: \${error}\`;
-  }
-};
-const runTest = async ({
-  page,`,
-        )
-        .replace(
-          `    const message = error instanceof Error ? error.message : \`\${error}\`;
-    return {
-      end,
-      error: message,`,
-          `    const message = error instanceof Error ? error.message : \`\${error}\`;
-    const diagnostics = await getPageDiagnostics(page);
-    return {
-      end,
-      error: message + diagnostics,`,
-        )
-        .replace(
-          `      case Fail:
-        failed++;
-        break;`,
-          `      case Fail:
-        failed++;
-        await onFinalResult({
-          end: performance.now(),
-          failed,
-          passed,
-          skipped,
-          start
-        });
-        return;`,
-        )
-        .replace(
-          `  const page = await browser.newPage();
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises`,
-          `  const page = await browser.newPage();
-  page.__lvceDiagnostics = {
-    badResponses: [],
-    console: [],
-    pageErrors: [],
-    requestFailures: []
-  };
-  page.on('console', message => page.__lvceDiagnostics.console.push({
-    type: message.type(),
-    text: message.text()
-  }));
-  page.on('pageerror', error => page.__lvceDiagnostics.pageErrors.push(\`\${error}\`));
-  page.on('requestfailed', request => page.__lvceDiagnostics.requestFailures.push({
-    errorText: request.failure()?.errorText,
-    url: request.url()
-  }));
-  page.on('response', response => {
-    if (response.status() >= 400) {
-      page.__lvceDiagnostics.badResponses.push({
-        status: response.status(),
-        url: response.url()
-      });
-    }
-  });
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises`,
-        )
-
-  if (newContent !== content) {
-    await writeFile(e2eWorkerPath, newContent)
-  }
-}
-
 await cp(join(root, 'dist'), staticPath, { recursive: true })
 await mkdir(staticPrefixPath, { recursive: true })
 await cp(join(staticPath, commitHash), join(staticPrefixPath, commitHash), { recursive: true })
 await cp(join(staticPath, 'favicon.ico'), join(staticPrefixPath, 'favicon.ico'))
 await patchServerStaticPrefix()
-await patchE2eDiagnostics()

--- a/packages/server/src/postinstall.js
+++ b/packages/server/src/postinstall.js
@@ -18,7 +18,6 @@ const textSearchWorkerPath = join(root, '.tmp', 'dist', 'dist', 'textSearchWorke
 
 const serverStaticPath = join(nodeModulesPath, '@lvce-editor', 'static-server', 'static')
 const serverMainPath = join(nodeModulesPath, '@lvce-editor', 'server', 'src', 'server.js')
-const e2eWorkerPath = join(root, 'packages', 'e2e', 'node_modules', '@lvce-editor', 'test-with-playwright-worker', 'dist', 'workerMain.js')
 
 const RE_COMMIT_HASH = /^[a-z\d]+$/
 const isCommitHash = (dirent) => {
@@ -28,7 +27,6 @@ const isCommitHash = (dirent) => {
 const dirents = await readdir(serverStaticPath)
 const commitHash = dirents.find(isCommitHash) || ''
 const rendererWorkerMainPath = join(serverStaticPath, commitHash, 'packages', 'renderer-worker', 'dist', 'rendererWorkerMain.js')
-const rendererProcessMainPath = join(serverStaticPath, commitHash, 'packages', 'renderer-process', 'dist', 'rendererProcessMain.js')
 
 const content = await readFile(rendererWorkerMainPath, 'utf-8')
 const remoteUrl = getRemoteUrl(textSearchWorkerPath)
@@ -36,45 +34,6 @@ const newContent = patchRendererWorker(content, remoteUrl, true)
 
 if (newContent !== content) {
   await writeFile(rendererWorkerMainPath, newContent)
-}
-
-const rendererProcessContent = await readFile(rendererProcessMainPath, 'utf-8')
-const rendererWorkerLaunchDiagnosticsSnippet = `return \`Failed to start \${displayName}: \${error}\`;`
-const rendererProcessWithDiagnostics = rendererProcessContent.includes(rendererWorkerLaunchDiagnosticsSnippet)
-  ? rendererProcessContent
-  : rendererProcessContent
-      .replace(
-        `const tryToGetActualErrorMessage = async ({
-  name
-}) => {
-  const displayName = getWorkerDisplayName(name);
-  return \`Failed to start \${displayName}: Worker Launch Error\`;
-};`,
-        `const tryToGetActualErrorMessage = async ({
-  name,
-  url
-}) => {
-  const displayName = getWorkerDisplayName(name);
-  try {
-    await import(url);
-    return \`Failed to start \${displayName}: Worker Launch Error\`;
-  } catch (error) {
-    return \`Failed to start \${displayName}: \${error}\`;
-  }
-};`,
-      )
-      .replace(
-        `const actualErrorMessage = await tryToGetActualErrorMessage({
-        name
-      });`,
-        `const actualErrorMessage = await tryToGetActualErrorMessage({
-        name,
-        url
-      });`,
-      )
-
-if (rendererProcessWithDiagnostics !== rendererProcessContent) {
-  await writeFile(rendererProcessMainPath, rendererProcessWithDiagnostics)
 }
 
 const serverContent = await readFile(serverMainPath, 'utf-8')
@@ -93,100 +52,4 @@ const newServerContent = serverContent.includes("url.startsWith('/text-search-wo
 
 if (newServerContent !== serverContent) {
   await writeFile(serverMainPath, newServerContent)
-}
-
-const e2eWorkerContent = await readFile(e2eWorkerPath, 'utf-8')
-const oldE2eDiagnosticsHelper = `const getPageDiagnostics = async page => {
-  try {
-    const html = await page.content();
-    return \`\\nURL: \${page.url()}\\nHTML: \${html.slice(0, 1200)}\`;
-  } catch (error) {
-    return \`\\nDiagnostics unavailable: \${error}\`;
-  }
-};
-`
-const normalizedE2eWorkerContent = e2eWorkerContent.replace(oldE2eDiagnosticsHelper, '')
-const e2eDiagnosticsSnippet = `PageErrors: \${JSON.stringify(diagnostics.pageErrors || [])}`
-const e2eWorkerWithDiagnostics = normalizedE2eWorkerContent.includes(e2eDiagnosticsSnippet)
-  ? normalizedE2eWorkerContent
-  : normalizedE2eWorkerContent
-      .replace(
-        `const runTest = async ({
-  page,`,
-        `const getPageDiagnostics = async page => {
-  try {
-    const html = await page.content();
-    const resourceEntries = await page.evaluate(() => performance.getEntriesByType('resource').map(entry => ({
-      name: entry.name,
-      duration: entry.duration,
-      transferSize: entry.transferSize,
-      responseStatus: entry.responseStatus
-    })).slice(-20));
-    const diagnostics = page.__lvceDiagnostics || {};
-    return \`\\nURL: \${page.url()}\\nConsole: \${JSON.stringify(diagnostics.console || [])}\\nPageErrors: \${JSON.stringify(diagnostics.pageErrors || [])}\\nRequestFailures: \${JSON.stringify(diagnostics.requestFailures || [])}\\nBadResponses: \${JSON.stringify(diagnostics.badResponses || [])}\\nResources: \${JSON.stringify(resourceEntries)}\\nHTML: \${html.slice(0, 1200)}\`;
-  } catch (error) {
-    return \`\\nDiagnostics unavailable: \${error}\`;
-  }
-};
-const runTest = async ({
-  page,`,
-      )
-      .replace(
-        `    const message = error instanceof Error ? error.message : \`\${error}\`;
-    return {
-      end,
-      error: message,`,
-        `    const message = error instanceof Error ? error.message : \`\${error}\`;
-    const diagnostics = await getPageDiagnostics(page);
-    return {
-      end,
-      error: message + diagnostics,`,
-      )
-      .replace(
-        `      case Fail:
-        failed++;
-        break;`,
-        `      case Fail:
-        failed++;
-        await onFinalResult({
-          end: performance.now(),
-          failed,
-          passed,
-          skipped,
-          start
-        });
-        return;`,
-      )
-      .replace(
-        `  const page = await browser.newPage();
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises`,
-        `  const page = await browser.newPage();
-  page.__lvceDiagnostics = {
-    badResponses: [],
-    console: [],
-    pageErrors: [],
-    requestFailures: []
-  };
-  page.on('console', message => page.__lvceDiagnostics.console.push({
-    type: message.type(),
-    text: message.text()
-  }));
-  page.on('pageerror', error => page.__lvceDiagnostics.pageErrors.push(\`\${error}\`));
-  page.on('requestfailed', request => page.__lvceDiagnostics.requestFailures.push({
-    errorText: request.failure()?.errorText,
-    url: request.url()
-  }));
-  page.on('response', response => {
-    if (response.status() >= 400) {
-      page.__lvceDiagnostics.badResponses.push({
-        status: response.status(),
-        url: response.url()
-      });
-    }
-  });
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises`,
-      )
-
-if (e2eWorkerWithDiagnostics !== e2eWorkerContent) {
-  await writeFile(e2eWorkerPath, e2eWorkerWithDiagnostics)
 }


### PR DESCRIPTION
## Summary\n- remove temporary e2e runner diagnostics added while debugging PR #1437\n- remove renderer-process worker launch diagnostic patch\n\n## Checks\n- npm run postinstall\n- npm run build:static\n- node --check packages/server/src/postinstall.js\n- node --check packages/build/src/build-static.js\n- node --check .tmp/static/995dbd2/packages/renderer-worker/dist/rendererWorkerMain.js