### PR TITLE
fix: focus search input when view is selected

### DIFF
--- a/packages/text-search-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/text-search-worker/src/parts/CommandMap/CommandMap.ts
@@ -110,6 +110,7 @@ export const commandMap = {
   'TextSearch.enableRenderFolderPaths': WrapCommand.wrapCommand(EnableRenderFolderPaths.enableRenderFolderPaths),
   'TextSearch.expandCurrent': WrapCommand.wrapCommand(ExpandCurrent.expandCurrent),
   'TextSearch.expandDetails': WrapCommand.wrapCommand(ExpandDetails.expandDetails),
+  'TextSearch.focus': WrapCommand.wrapCommand(SearchFocus.focusSearchValue),
   'TextSearch.focusFirst': WrapCommand.wrapCommand(ListFocusFirst.focusFirst),
   'TextSearch.focusIndex': WrapCommand.wrapCommand(ListFocusIndex.focusIndex),
   'TextSearch.focusLast': WrapCommand.wrapCommand(ListFocusLast.focusLast),


### PR DESCRIPTION
Expose the generic search view focus command so selecting Search can focus its input.