### PR TITLE
feature: split search field button functions

### DIFF
--- a/packages/text-search-worker/src/parts/GetAriaChecked/GetAriaChecked.ts
+++ b/packages/text-search-worker/src/parts/GetAriaChecked/GetAriaChecked.ts
@@ -1,0 +1,13 @@
+import * as InputActionFlag from '../InputActionFlag/InputActionFlag.ts'
+
+// TODO maybe move logic to viewmodel, which returns ariaChecked 1 | 2 | 3
+export const getAriaChecked = (flag: number): boolean | undefined => {
+  switch (flag) {
+    case InputActionFlag.CheckBoxDisabled:
+      return false
+    case InputActionFlag.CheckBoxEnabled:
+      return true
+    default:
+      return undefined
+  }
+}

--- a/packages/text-search-worker/src/parts/GetDisabled/GetDisabled.ts
+++ b/packages/text-search-worker/src/parts/GetDisabled/GetDisabled.ts
@@ -1,0 +1,10 @@
+import * as InputActionFlag from '../InputActionFlag/InputActionFlag.ts'
+
+export const getDisabled = (flag: number): boolean | undefined => {
+  switch (flag) {
+    case InputActionFlag.ButtonDisabled:
+      return true
+    default:
+      return undefined
+  }
+}

--- a/packages/text-search-worker/src/parts/GetRole/GetRole.ts
+++ b/packages/text-search-worker/src/parts/GetRole/GetRole.ts
@@ -1,0 +1,13 @@
+import { AriaRoles } from '@lvce-editor/constants'
+import * as InputActionFlag from '../InputActionFlag/InputActionFlag.ts'
+
+// TODO have have separate renderers for checkbox and button elements
+export const getRole = (flag: number): string | undefined => {
+  switch (flag) {
+    case InputActionFlag.CheckBoxDisabled:
+    case InputActionFlag.CheckBoxEnabled:
+      return AriaRoles.CheckBox
+    default:
+      return undefined
+  }
+}

--- a/packages/text-search-worker/src/parts/GetSearchFieldButtonVirtualDom/GetSearchFieldButtonVirtualDom.ts
+++ b/packages/text-search-worker/src/parts/GetSearchFieldButtonVirtualDom/GetSearchFieldButtonVirtualDom.ts
@@ -1,51 +1,20 @@
-import { AriaRoles } from '@lvce-editor/constants'
 import { ClassNames } from '@lvce-editor/virtual-dom-worker'
 import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import type { InputAction } from '../InputAction/InputAction.ts'
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
+import * as GetAriaChecked from '../GetAriaChecked/GetAriaChecked.ts'
+import * as GetDisabled from '../GetDisabled/GetDisabled.ts'
+import * as GetRole from '../GetRole/GetRole.ts'
 import * as GetSearchFieldButtonClassName from '../GetSearchFieldButtonClassName/GetSearchFieldButtonClassName.ts'
-import * as InputActionFlag from '../InputActionFlag/InputActionFlag.ts'
 import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as TabIndex from '../TabIndex/TabIndex.ts'
 
-// TODO maybe move logic to viewmodel, which returns ariaChecked 1 | 2 | 3
-const getAriaChecked = (flag: number): boolean | undefined => {
-  switch (flag) {
-    case InputActionFlag.CheckBoxDisabled:
-      return false
-    case InputActionFlag.CheckBoxEnabled:
-      return true
-    default:
-      return undefined
-  }
-}
-
-// TODO have have separate renderers for checkbox and button elements
-const getRole = (flag: number): string | undefined => {
-  switch (flag) {
-    case InputActionFlag.CheckBoxDisabled:
-    case InputActionFlag.CheckBoxEnabled:
-      return AriaRoles.CheckBox
-    default:
-      return undefined
-  }
-}
-
-const getDisabled = (flag: number): boolean | undefined => {
-  switch (flag) {
-    case InputActionFlag.ButtonDisabled:
-      return true
-    default:
-      return undefined
-  }
-}
-
 export const getSearchFieldButtonVirtualDom = (button: InputAction): readonly VirtualDomNode[] => {
   const { flag, icon, name, title } = button
-  const ariaChecked = getAriaChecked(flag)
-  const role = getRole(flag)
-  const disabled = getDisabled(flag)
+  const ariaChecked = GetAriaChecked.getAriaChecked(flag)
+  const role = GetRole.getRole(flag)
+  const disabled = GetDisabled.getDisabled(flag)
   return [
     {
       ariaChecked,

--- a/packages/text-search-worker/test/GetAriaChecked.test.ts
+++ b/packages/text-search-worker/test/GetAriaChecked.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@jest/globals'
+import * as GetAriaChecked from '../src/parts/GetAriaChecked/GetAriaChecked.ts'
+import * as InputActionFlag from '../src/parts/InputActionFlag/InputActionFlag.ts'
+
+test('getAriaChecked - checkbox disabled', () => {
+  expect(GetAriaChecked.getAriaChecked(InputActionFlag.CheckBoxDisabled)).toBe(false)
+})
+
+test('getAriaChecked - checkbox enabled', () => {
+  expect(GetAriaChecked.getAriaChecked(InputActionFlag.CheckBoxEnabled)).toBe(true)
+})
+
+test('getAriaChecked - unknown flag', () => {
+  expect(GetAriaChecked.getAriaChecked(-1)).toBe(undefined)
+})

--- a/packages/text-search-worker/test/GetDisabled.test.ts
+++ b/packages/text-search-worker/test/GetDisabled.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@jest/globals'
+import * as GetDisabled from '../src/parts/GetDisabled/GetDisabled.ts'
+import * as InputActionFlag from '../src/parts/InputActionFlag/InputActionFlag.ts'
+
+test('getDisabled - button disabled', () => {
+  expect(GetDisabled.getDisabled(InputActionFlag.ButtonDisabled)).toBe(true)
+})
+
+test('getDisabled - button enabled', () => {
+  expect(GetDisabled.getDisabled(InputActionFlag.ButtonEnabled)).toBe(undefined)
+})
+
+test('getDisabled - unknown flag', () => {
+  expect(GetDisabled.getDisabled(-1)).toBe(undefined)
+})

--- a/packages/text-search-worker/test/GetRole.test.ts
+++ b/packages/text-search-worker/test/GetRole.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@jest/globals'
+import { AriaRoles } from '@lvce-editor/constants'
+import * as GetRole from '../src/parts/GetRole/GetRole.ts'
+import * as InputActionFlag from '../src/parts/InputActionFlag/InputActionFlag.ts'
+
+test('getRole - checkbox disabled', () => {
+  expect(GetRole.getRole(InputActionFlag.CheckBoxDisabled)).toBe(AriaRoles.CheckBox)
+})
+
+test('getRole - checkbox enabled', () => {
+  expect(GetRole.getRole(InputActionFlag.CheckBoxEnabled)).toBe(AriaRoles.CheckBox)
+})
+
+test('getRole - button disabled', () => {
+  expect(GetRole.getRole(InputActionFlag.ButtonDisabled)).toBe(undefined)
+})
+
+test('getRole - unknown flag', () => {
+  expect(GetRole.getRole(-1)).toBe(undefined)
+})

--- a/packages/text-search-worker/test/GetSearchFieldButtonVirtualDom.test.ts
+++ b/packages/text-search-worker/test/GetSearchFieldButtonVirtualDom.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@jest/globals'
+import { AriaRoles } from '@lvce-editor/constants'
+import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
+import type { InputAction } from '../src/parts/InputAction/InputAction.ts'
+import * as DomEventListenerFunctions from '../src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts'
+import * as GetSearchFieldButtonVirtualDom from '../src/parts/GetSearchFieldButtonVirtualDom/GetSearchFieldButtonVirtualDom.ts'
+import * as InputActionFlag from '../src/parts/InputActionFlag/InputActionFlag.ts'
+
+test('getSearchFieldButtonVirtualDom - enabled checkbox', () => {
+  const button: InputAction = {
+    flag: InputActionFlag.CheckBoxEnabled,
+    icon: 'MaskIconCaseSensitive',
+    name: 'MatchCase',
+    title: 'Match Case',
+  }
+
+  expect(GetSearchFieldButtonVirtualDom.getSearchFieldButtonVirtualDom(button)).toEqual([
+    {
+      ariaChecked: true,
+      childCount: 1,
+      className: 'SearchFieldButton SearchFieldButtonChecked',
+      disabled: undefined,
+      name: 'MatchCase',
+      onClick: DomEventListenerFunctions.HandleButtonClick,
+      role: AriaRoles.CheckBox,
+      tabIndex: 0,
+      title: 'Match Case',
+      type: VirtualDomElements.Button,
+    },
+    {
+      childCount: 0,
+      className: 'MaskIcon MaskIconCaseSensitive',
+      type: VirtualDomElements.Span,
+    },
+  ])
+})
+
+test('getSearchFieldButtonVirtualDom - disabled button', () => {
+  const button: InputAction = {
+    flag: InputActionFlag.ButtonDisabled,
+    icon: 'MaskIconReplaceAll',
+    name: 'ReplaceAll',
+    title: 'Replace All',
+  }
+
+  expect(GetSearchFieldButtonVirtualDom.getSearchFieldButtonVirtualDom(button)).toEqual([
+    {
+      ariaChecked: undefined,
+      childCount: 1,
+      className: 'SearchFieldButton SearchFieldButtonDisabled',
+      disabled: true,
+      name: 'ReplaceAll',
+      onClick: DomEventListenerFunctions.HandleButtonClick,
+      role: undefined,
+      tabIndex: 0,
+      title: 'Replace All',
+      type: VirtualDomElements.Button,
+    },
+    {
+      childCount: 0,
+      className: 'MaskIcon MaskIconReplaceAll',
+      type: VirtualDomElements.Span,
+    },
+  ])
+})


### PR DESCRIPTION
Splits the search field button renderer helpers into dedicated modules and adds direct unit coverage for each function.