### PR TITLE
fix: open search results at match range

### DIFF
--- a/packages/text-search-worker/src/parts/SearchResult/SearchResult.ts
+++ b/packages/text-search-worker/src/parts/SearchResult/SearchResult.ts
@@ -1,7 +1,10 @@
 export interface SearchResult {
   readonly end: number
+  readonly endColumnIndex?: number
   readonly lineNumber: number
+  readonly rowIndex?: number
   readonly start: number
+  readonly startColumnIndex?: number
   readonly text: string
   readonly type: number
 }

--- a/packages/text-search-worker/src/parts/SelectIndexPreview/SelectIndexPreview.ts
+++ b/packages/text-search-worker/src/parts/SelectIndexPreview/SelectIndexPreview.ts
@@ -1,22 +1,23 @@
 import { WhenExpression } from '@lvce-editor/virtual-dom-worker'
+import type { SearchResult } from '../SearchResult/SearchResult.ts'
 import type { SearchState } from '../SearchState/SearchState.ts'
 import * as GetFileIndex from '../GetFileIndex/GetFileIndex.ts'
 import * as InputSource from '../InputSource/InputSource.ts'
 import * as OpenUri from '../OpenUri/OpenUri.ts'
 import * as Workspace from '../Workspace/Workspace.ts'
 
-export const selectIndexPreview = async (state: SearchState, searchResult: any, index: number): Promise<SearchState> => {
+export const selectIndexPreview = async (state: SearchState, searchResult: SearchResult, index: number): Promise<SearchState> => {
   const { items, workspacePath } = state
   const fileIndex = GetFileIndex.getFileIndex(items, index)
   if (fileIndex === -1) {
     throw new Error('Search result is missing file')
   }
-  const { lineNumber } = searchResult
+  const { end, endColumnIndex = end, lineNumber, rowIndex = lineNumber, start, startColumnIndex = start } = searchResult
   const fileResult = items[fileIndex]
   const relativePath = Workspace.getRelativePath(fileResult.text)
   const absolutePath = `${workspacePath}${relativePath}`
   await OpenUri.openUri(absolutePath, true, {
-    selections: new Uint32Array([lineNumber, 0, lineNumber, 0]),
+    selections: new Uint32Array([rowIndex, startColumnIndex, rowIndex, endColumnIndex]),
   })
   return {
     ...state,

--- a/packages/text-search-worker/test/SelectIndex.test.ts
+++ b/packages/text-search-worker/test/SelectIndex.test.ts
@@ -78,7 +78,16 @@ test('getFileIndex - finds closest file above match', async () => {
     items: [
       { end: 0, lineNumber: 0, start: 0, text: 'file1.ts', type: TextSearchResultType.File },
       { end: 0, lineNumber: 5, start: 0, text: '', type: TextSearchResultType.Match },
-      { end: 0, lineNumber: 10, start: 0, text: '', type: TextSearchResultType.Match },
+      {
+        end: 28,
+        endColumnIndex: 313,
+        lineNumber: 10,
+        rowIndex: 9,
+        start: 26,
+        startColumnIndex: 311,
+        text: '',
+        type: TextSearchResultType.Match,
+      },
       { end: 0, lineNumber: 0, start: 0, text: 'file2.ts', type: TextSearchResultType.File },
     ],
     workspacePath: '/test',
@@ -87,7 +96,7 @@ test('getFileIndex - finds closest file above match', async () => {
   state.listItems = state.items
 
   await SelectIndex.selectIndex(state, 2) // Select second match
-  expect(mockRpc.invocations).toEqual([['Main.openUri', '/test/file1.ts', true, { selections: new Uint32Array([10, 0, 10, 0]) }]])
+  expect(mockRpc.invocations).toEqual([['Main.openUri', '/test/file1.ts', true, { selections: new Uint32Array([9, 311, 9, 313]) }]])
 })
 
 test('getFileIndex - returns -1 when no file found', async () => {
@@ -106,7 +115,7 @@ test('getFileIndex - returns -1 when no file found', async () => {
   expect(mockRpc.invocations).toEqual([])
 })
 
-test('selectIndexPreview - handles match with file above', async () => {
+test('selectIndexPreview - uses extension search result coordinates as fallback', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'Main.openUri': () => undefined,
   })
@@ -116,7 +125,7 @@ test('selectIndexPreview - handles match with file above', async () => {
     items: [
       { end: 0, lineNumber: 0, start: 0, text: 'file1.ts', type: TextSearchResultType.File },
       { end: 0, lineNumber: 5, start: 0, text: '', type: TextSearchResultType.Match },
-      { end: 0, lineNumber: 10, start: 0, text: '', type: TextSearchResultType.Match },
+      { end: 8, lineNumber: 10, start: 4, text: '', type: TextSearchResultType.Match },
       { end: 0, lineNumber: 0, start: 0, text: 'file2.ts', type: TextSearchResultType.File },
     ],
     workspacePath: '/test',
@@ -133,5 +142,5 @@ test('selectIndexPreview - handles match with file above', async () => {
     listFocused: false,
     listFocusedIndex: 2,
   })
-  expect(mockRpc.invocations).toEqual([['Main.openUri', '/test/file1.ts', true, { selections: new Uint32Array([10, 0, 10, 0]) }]])
+  expect(mockRpc.invocations).toEqual([['Main.openUri', '/test/file1.ts', true, { selections: new Uint32Array([10, 4, 10, 8]) }]])
 })


### PR DESCRIPTION
Opens native text-search results at their zero-based row and absolute match columns, while preserving extension search coordinate compatibility.