### PR TITLE
Request WebSocket capabilities for search RPC

### DIFF
--- a/packages/text-search-worker/src/parts/LaunchSearchProcessNode/LaunchSearchProcessNode.ts
+++ b/packages/text-search-worker/src/parts/LaunchSearchProcessNode/LaunchSearchProcessNode.ts
@@ -1,7 +1,22 @@
-import { type Rpc, LazyWebSocketRpcParent2 } from '@lvce-editor/rpc'
+import { type Rpc, LazyWebSocketRpcParent2, WebSocketRpcParent } from '@lvce-editor/rpc'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as CommandMapRef from '../CommandMapRef/CommandMapRef.ts'
 
 export const launchSearchProcessNode = async (): Promise<Rpc> => {
+  try {
+    const { protocols, url } = (await RendererWorker.invoke('WebSocketCapability.create', 'search-process')) as {
+      readonly protocols: string[]
+      readonly url: string
+    }
+    return WebSocketRpcParent.create({
+      commandMap: CommandMapRef.commandMapRef,
+      webSocket: new WebSocket(url, protocols),
+    })
+  } catch (error) {
+    if (!(error instanceof Error && error.message.includes('WebSocketCapability.create') && /command not found|not found/i.test(error.message))) {
+      throw error
+    }
+  }
   return LazyWebSocketRpcParent2.create({
     commandMap: CommandMapRef.commandMapRef,
     // @ts-ignore


### PR DESCRIPTION
Requests a renderer-issued one-use capability before connecting to the search process, with a command-missing fallback for older editors.