### PR TITLE
fix: support pre-capability renderers

### DIFF
--- a/packages/text-search-worker/src/parts/LaunchSearchProcessNode/LaunchSearchProcessNode.ts
+++ b/packages/text-search-worker/src/parts/LaunchSearchProcessNode/LaunchSearchProcessNode.ts
@@ -13,7 +13,11 @@ export const launchSearchProcessNode = async (): Promise<Rpc> => {
       webSocket: new WebSocket(url, protocols),
     })
   } catch (error) {
-    if (!(error instanceof Error && error.message.includes('WebSocketCapability.create') && /command not found|not found/i.test(error.message))) {
+    if (!(
+      error instanceof Error &&
+      (error.message.includes('WebSocketCapability.create') || error.message.includes('module WebSocketCapability not found')) &&
+      /command not found|not found/i.test(error.message)
+    )) {
       throw error
     }
   }


### PR DESCRIPTION
## Summary

Recognize the exact missing WebSocketCapability module error returned by older renderer builds and use the existing legacy transport during the dependency-first rollout.

Authorization and connection errors still do not downgrade to the legacy transport.

Follow-up to the capability-gated RPC producer migration.