### PR TITLE
fix: request text search context lines

### DIFF
--- a/packages/text-search-worker/src/parts/GetTextSearchRipGrepArgs/GetTextSearchRipGrepArgs.ts
+++ b/packages/text-search-worker/src/parts/GetTextSearchRipGrepArgs/GetTextSearchRipGrepArgs.ts
@@ -1,4 +1,12 @@
+const getContextArgs = (contextLines?: number): readonly string[] => {
+  if (contextLines && contextLines > 0) {
+    return ['--context', `${Math.trunc(contextLines)}`]
+  }
+  return []
+}
+
 export const getRipGrepArgs = ({
+  contextLines,
   defaultExcludes,
   exclude,
   isCaseSensitive,
@@ -8,6 +16,7 @@ export const getRipGrepArgs = ({
   useIgnoreFiles = true,
   useRegularExpression,
 }: {
+  readonly contextLines?: number
   readonly defaultExcludes?: readonly string[]
   readonly exclude?: string
   readonly threads: number
@@ -17,7 +26,16 @@ export const getRipGrepArgs = ({
   readonly useIgnoreFiles?: boolean
   readonly useRegularExpression: boolean
 }): readonly string[] => {
-  const ripGrepArgs = ['--hidden', '--no-require-git', '--smart-case', '--stats', '--json', '--threads', `${threads}`]
+  const ripGrepArgs = [
+    '--hidden',
+    '--no-require-git',
+    '--smart-case',
+    '--stats',
+    '--json',
+    '--threads',
+    `${threads}`,
+    ...getContextArgs(contextLines),
+  ]
   if (!useIgnoreFiles) {
     ripGrepArgs.push('--no-ignore')
   }

--- a/packages/text-search-worker/src/parts/TextSearchOptions/TextSearchOptions.ts
+++ b/packages/text-search-worker/src/parts/TextSearchOptions/TextSearchOptions.ts
@@ -1,5 +1,6 @@
 export interface TextSearchOptions {
   readonly assetDir: string
+  readonly contextLines?: number
   readonly defaultExcludes?: readonly string[]
   readonly exclude: string
   readonly flags: number

--- a/packages/text-search-worker/test/GetTextSearchRipGrepArgs.test.ts
+++ b/packages/text-search-worker/test/GetTextSearchRipGrepArgs.test.ts
@@ -49,6 +49,45 @@ test('getRipGrepArgs - isCaseSensitive', () => {
   ])
 })
 
+test('getRipGrepArgs - context lines', () => {
+  expect(
+    GetTextSearchRipGrepArgs.getRipGrepArgs({
+      contextLines: 2,
+      isCaseSensitive: false,
+      searchString: 'test',
+      threads: 1,
+      useRegularExpression: false,
+    }),
+  ).toEqual([
+    '--hidden',
+    '--no-require-git',
+    '--smart-case',
+    '--stats',
+    '--json',
+    '--threads',
+    '1',
+    '--context',
+    '2',
+    '--ignore-case',
+    '--fixed-strings',
+    '--',
+    'test',
+    '.',
+  ])
+})
+
+test('getRipGrepArgs - disabled context lines', () => {
+  const args = GetTextSearchRipGrepArgs.getRipGrepArgs({
+    contextLines: 0,
+    isCaseSensitive: false,
+    searchString: 'test',
+    threads: 1,
+    useRegularExpression: false,
+  })
+
+  expect(args).not.toContain('--context')
+})
+
 test('getRipGrepArgs - useRegularExpression', () => {
   expect(
     GetTextSearchRipGrepArgs.getRipGrepArgs({


### PR DESCRIPTION
Forward the requested context-line count to ripgrep while preserving the existing disabled behavior.