### PR TITLE
fix: apply search include and open editor filters

### DIFF
--- a/packages/text-search-worker/src/parts/GetOpenEditorPaths/GetOpenEditorPaths.ts
+++ b/packages/text-search-worker/src/parts/GetOpenEditorPaths/GetOpenEditorPaths.ts
@@ -1,0 +1,26 @@
+const normalizeWindowsDrive = (path: string): string => {
+  return /^\/[A-Za-z]:\//.test(path) ? path.slice(1) : path
+}
+
+const toPath = (uri: string): string => {
+  if (uri.startsWith('file://')) {
+    return normalizeWindowsDrive(decodeURIComponent(new URL(uri).pathname)).replaceAll('\\', '/')
+  }
+  if (/^[A-Za-z]:[\\/]/.test(uri)) {
+    return uri.replaceAll('\\', '/')
+  }
+  if (/^[A-Za-z][A-Za-z\d+.-]*:/.test(uri)) {
+    return ''
+  }
+  return uri.replaceAll('\\', '/')
+}
+
+export const getOpenEditorPaths = (root: string, openEditorUris: readonly string[]): readonly string[] => {
+  const rootPath = toPath(root).replace(/\/$/, '')
+  const rootPrefix = `${rootPath}/`
+  const paths = openEditorUris
+    .map(toPath)
+    .filter((path) => path.startsWith(rootPrefix))
+    .map((path) => path.slice(rootPrefix.length))
+  return [...new Set(paths)]
+}

--- a/packages/text-search-worker/src/parts/GetTextSearchRipGrepArgs/GetTextSearchRipGrepArgs.ts
+++ b/packages/text-search-worker/src/parts/GetTextSearchRipGrepArgs/GetTextSearchRipGrepArgs.ts
@@ -5,12 +5,22 @@ const getContextArgs = (contextLines?: number): readonly string[] => {
   return []
 }
 
+const getIncludeArgs = (include?: string): readonly string[] => {
+  return (include || '')
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .flatMap((pattern) => ['--glob', pattern])
+}
+
 export const getRipGrepArgs = ({
   contextLines,
   defaultExcludes,
   exclude,
+  include,
   isCaseSensitive,
   matchWholeWord,
+  paths,
   searchString,
   threads,
   useIgnoreFiles = true,
@@ -19,6 +29,8 @@ export const getRipGrepArgs = ({
   readonly contextLines?: number
   readonly defaultExcludes?: readonly string[]
   readonly exclude?: string
+  readonly include?: string
+  readonly paths?: readonly string[]
   readonly threads: number
   readonly isCaseSensitive: boolean
   readonly matchWholeWord?: boolean
@@ -57,6 +69,7 @@ export const getRipGrepArgs = ({
       ripGrepArgs.push('--glob', `!**/${excludePattern}/**`)
     }
   }
+  ripGrepArgs.push(...getIncludeArgs(include))
   if (isCaseSensitive) {
     ripGrepArgs.push('--case-sensitive')
   } else {
@@ -72,6 +85,6 @@ export const getRipGrepArgs = ({
     ripGrepArgs.push('--')
     ripGrepArgs.push(searchString)
   }
-  ripGrepArgs.push('.')
+  ripGrepArgs.push(...(paths || ['.']))
   return ripGrepArgs
 }

--- a/packages/text-search-worker/src/parts/TextSearchNode/TextSearchNode.ts
+++ b/packages/text-search-worker/src/parts/TextSearchNode/TextSearchNode.ts
@@ -1,5 +1,6 @@
 import type { TextSearchCompletionResult } from '../TextSearchCompletionResult/TextSearchCompletionResult.ts'
 import type { TextSearchOptions } from '../TextSearchOptions/TextSearchOptions.ts'
+import * as GetOpenEditorPaths from '../GetOpenEditorPaths/GetOpenEditorPaths.ts'
 import * as GetTextSearchRipGrepArgs from '../GetTextSearchRipGrepArgs/GetTextSearchRipGrepArgs.ts'
 import * as InvokeSearchProcess from '../InvokeSearchProcess/InvokeSearchProcess.ts'
 
@@ -13,8 +14,16 @@ export const textSearch = async (
   searchId?: string,
   uid?: number,
 ): Promise<TextSearchCompletionResult> => {
+  const openEditorPaths = options.openEditorUris ? GetOpenEditorPaths.getOpenEditorPaths(root, options.openEditorUris) : undefined
+  if (openEditorPaths && openEditorPaths.length === 0) {
+    return {
+      limitHit: false,
+      results: [],
+    }
+  }
   const ripGrepArgs = GetTextSearchRipGrepArgs.getRipGrepArgs({
     ...options,
+    ...(openEditorPaths && { paths: openEditorPaths }),
     searchString: query,
   })
   if (options.usePullBasedSearch && searchId && (scheme === '' || scheme === 'file')) {

--- a/packages/text-search-worker/src/parts/TextSearchOptions/TextSearchOptions.ts
+++ b/packages/text-search-worker/src/parts/TextSearchOptions/TextSearchOptions.ts
@@ -8,6 +8,7 @@ export interface TextSearchOptions {
   readonly isCaseSensitive: boolean
   readonly limit: number
   readonly matchWholeWord: boolean
+  readonly openEditorUris?: readonly string[]
 
   readonly query: string
   readonly root: string

--- a/packages/text-search-worker/test/GetOpenEditorPaths.test.ts
+++ b/packages/text-search-worker/test/GetOpenEditorPaths.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@jest/globals'
+import * as GetOpenEditorPaths from '../src/parts/GetOpenEditorPaths/GetOpenEditorPaths.ts'
+
+test('getOpenEditorPaths - returns unique workspace-relative file paths', () => {
+  expect(
+    GetOpenEditorPaths.getOpenEditorPaths('file:///workspace', [
+      'file:///workspace/src/app.ts',
+      'file:///workspace/docs/guide%20one.md',
+      'file:///workspace/src/app.ts',
+      'search-editor://1/Search',
+      'file:///other/outside.ts',
+    ]),
+  ).toEqual(['src/app.ts', 'docs/guide one.md'])
+})
+
+test('getOpenEditorPaths - supports plain and Windows paths', () => {
+  expect(GetOpenEditorPaths.getOpenEditorPaths('/workspace/', ['/workspace/src/app.ts'])).toEqual(['src/app.ts'])
+  expect(GetOpenEditorPaths.getOpenEditorPaths('file:///C:/workspace', ['file:///C:/workspace/src/app.ts'])).toEqual(['src/app.ts'])
+  expect(GetOpenEditorPaths.getOpenEditorPaths('C:\\workspace', ['C:\\workspace\\src\\app.ts'])).toEqual(['src/app.ts'])
+})

--- a/packages/text-search-worker/test/GetTextSearchRipGrepArgs.test.ts
+++ b/packages/text-search-worker/test/GetTextSearchRipGrepArgs.test.ts
@@ -154,6 +154,47 @@ test('getRipGrepArgs - exclude', () => {
   ])
 })
 
+test('getRipGrepArgs - include', () => {
+  expect(
+    GetTextSearchRipGrepArgs.getRipGrepArgs({
+      include: '*.ts, src/**',
+      isCaseSensitive: false,
+      searchString: 'test',
+      threads: 1,
+      useRegularExpression: false,
+    }),
+  ).toEqual([
+    '--hidden',
+    '--no-require-git',
+    '--smart-case',
+    '--stats',
+    '--json',
+    '--threads',
+    '1',
+    '--glob',
+    '*.ts',
+    '--glob',
+    'src/**',
+    '--ignore-case',
+    '--fixed-strings',
+    '--',
+    'test',
+    '.',
+  ])
+})
+
+test('getRipGrepArgs - explicit paths', () => {
+  const result = GetTextSearchRipGrepArgs.getRipGrepArgs({
+    isCaseSensitive: false,
+    paths: ['src/app.ts', 'README.md'],
+    searchString: 'test',
+    threads: 1,
+    useRegularExpression: false,
+  })
+
+  expect(result.slice(-2)).toEqual(['src/app.ts', 'README.md'])
+})
+
 test('getRipGrepArgs - default excludes when UseIgnoreFiles is enabled', () => {
   expect(
     GetTextSearchRipGrepArgs.getRipGrepArgs({

--- a/packages/text-search-worker/test/TextSearchNode.test.ts
+++ b/packages/text-search-worker/test/TextSearchNode.test.ts
@@ -81,6 +81,61 @@ test('textSearch', async () => {
   ])
 })
 
+test('textSearch - returns no results when only open editors is enabled without file editors', async () => {
+  const handler = jest.fn()
+  using mockRpc = RendererWorker.registerMockRpc({
+    'SearchProcess.invoke': handler,
+  })
+
+  await expect(TextSearchNode.textSearch('', '/test', 'abc', { openEditorUris: [] } as any)).resolves.toEqual({
+    limitHit: false,
+    results: [],
+  })
+  expect(mockRpc.invocations).toEqual([])
+})
+
+test('textSearch - limits results to open editors inside the workspace', async () => {
+  const handler = jest.fn(() => ({
+    limitHit: false,
+    results: [],
+  }))
+  using mockRpc = RendererWorker.registerMockRpc({
+    'SearchProcess.invoke': handler,
+  })
+
+  await expect(
+    TextSearchNode.textSearch('', '/test', 'abc', {
+      openEditorUris: ['file:///test/src/app.ts', 'file:///outside/app.ts'],
+    } as any),
+  ).resolves.toEqual({
+    limitHit: false,
+    results: [],
+  })
+  expect(mockRpc.invocations).toEqual([
+    [
+      'SearchProcess.invoke',
+      'TextSearch.search',
+      {
+        ripGrepArgs: [
+          '--hidden',
+          '--no-require-git',
+          '--smart-case',
+          '--stats',
+          '--json',
+          '--threads',
+          'undefined',
+          '--ignore-case',
+          '--fixed-strings',
+          '--',
+          'abc',
+          'src/app.ts',
+        ],
+        searchDir: '/test',
+      },
+    ],
+  ])
+})
+
 test('textSearch - pull based (file scheme)', async () => {
   const handler = jest.fn(() => undefined)
   using mockRpc = RendererWorker.registerMockRpc({


### PR DESCRIPTION
## Summary

- pass include patterns to ripgrep as positive globs
- limit Open Editors searches to workspace-relative file editor paths
- return no results when Open Editors is selected without open workspace files

## Testing

- npm test
- npm run type-check
- npm run lint
- npm run build